### PR TITLE
Notebook update: Timeseries Tools 

### DIFF
--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -42,6 +42,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "54b4b6bf-8949-4155-ac6d-e9a686347278",
+   "metadata": {},
+   "source": [
+    "Additionally, get set up to make the computing go faster, by executing this cell:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80537bea-0a3a-44ac-a5c8-4bef62f22e0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask_gateway import GatewayCluster\n",
+    "cluster = GatewayCluster()\n",
+    "cluster.adapt(minimum=0, maximum=8)\n",
+    "client = cluster.get_client()\n",
+    "cluster"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7128a831-6c48-4bb9-bd51-2677b31be3aa",
@@ -242,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -79,7 +79,7 @@
    "metadata": {},
    "source": [
     "## Step 1: Select\n",
-    "You will want to choose \"Append historical\" and \"Area average\" if your intention is to work with the timeseries tools."
+    "Be sure to select \"Append historical\" and \"Area average\" in order to work with the timeseries tools."
    ]
   },
   {
@@ -245,6 +245,24 @@
    "outputs": [],
    "source": [
     "app.export_dataset(transformed,'my_filename')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5614d47-642d-4d3e-af25-d8a617371aa1",
+   "metadata": {},
+   "source": [
+    "Lastly, when you are done, close your cluster resources to free them up for the next time you work. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5414eb1b-3734-411e-bb11-ad8b95c96f36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.close()"
    ]
   }
  ],

--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -103,7 +103,8 @@
    "id": "6adfd743-aef3-46b9-9ddf-e5d63dac7773",
    "metadata": {},
    "source": [
-    "### For the timeseries 'explore' function, we first need to load the dataset, so that the subsequent operations will be speedy. \n",
+    "For the timeseries 'explore' function, we first need to load the dataset, so that the subsequent operations will be speedy. \n",
+    "\n",
     "The 'retreive' step above previews, but does not compute, the aggregation of all the selected data into timeseries. This may take a few minutes."
    ]
   },
@@ -140,7 +141,7 @@
    "id": "59ac5d9a-d4fb-4747-bb45-43bb398a835c",
    "metadata": {},
    "source": [
-    "### Preview various transforms on the data in real time."
+    "Preview various transforms on the data in real time."
    ]
   },
   {
@@ -156,9 +157,11 @@
   {
    "cell_type": "markdown",
    "id": "1263b30d-9bca-4344-b70f-245bbd7c8315",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
-    "### And then output whatever the current state is to another variable:"
+    "And then output whatever the current state is to another variable:"
    ]
   },
   {
@@ -188,7 +191,10 @@
    "source": [
     "## Step 5: Export\n",
     "\n",
-    "Use the below code to export a dataset as a NetCDF, GeoTIFF, or CSV file. "
+    "To export, first pick a format from the dropdown menu.\n",
+    "- We recommend NetCDF, which will work with any number of variables and dimensions in your dataset\n",
+    "- CSV works best up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
+    "- GeoTIFF is not possible as the time series data does not retain a spatial component"
    ]
   },
   {
@@ -206,11 +212,7 @@
    "id": "cd729c6a-62e4-4388-b570-7b6ce76a3712",
    "metadata": {},
    "source": [
-    "Provide the name of the dataset in the environment to export as well as a character string containing the file name in quotations. \n",
-    "\n",
-    "If the dataset contains multiple variables, provide an argument specifying which variable to export (e.g. variable=”T2”). \n",
-    "\n",
-    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”)."
+    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
    ]
   },
   {
@@ -240,7 +242,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Splitting PRs per notebook, so apologies in advance for the multiple review requests. 

This PR updates our timeseries notebook for export and cleaned up some markdown text size. 

**To test**: 
1. Run through notebook
2. Check that export works for the timeseries data as a:
-  **netcdf**
-  **csv**
 
 GeoTIFF will not work as it is a timeseries, and the markdown text is updated to reflect this. 