### PR TITLE
Notebook update: Threshold Basics

### DIFF
--- a/threshold_tools_basics.ipynb
+++ b/threshold_tools_basics.ipynb
@@ -65,6 +65,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0444b879-9e3c-4ba2-a830-57e36c88a30b",
+   "metadata": {},
+   "source": [
+    "Additionally, get set up to make the computing go faster, by executing the following cell. It may take a minute or two to spin up!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5fc721f-5043-4e1e-83aa-f71b3be42ee6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask_gateway import GatewayCluster\n",
+    "cluster = GatewayCluster()\n",
+    "cluster.adapt(minimum=0, maximum=16)\n",
+    "client = cluster.get_client()\n",
+    "cluster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "49d7b471-cf37-4f74-8d50-b29fd6f5bbc1",
    "metadata": {},
    "source": [
@@ -194,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subsetted_data = generated_data.sel(scenario='Historical + SSP 3-7.0 -- Business as Usual').sel(simulation='cnrm-esm2-1')\n",
+    "subsetted_data = generated_data.sel(scenario='Historical Climate').sel(simulation='cnrm-esm2-1')\n",
     "subsetted_data"
    ]
   },
@@ -568,12 +590,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b57e04f1-c3eb-40dd-806f-06e2e86b5c05",
+   "metadata": {},
+   "source": [
+    "Lastly, when you are done, close your cluster resources to free them up for the next time you work. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a863707-9f75-4feb-ad2e-1dc31a050a9a",
+   "id": "e23c484c-b1c8-444f-875c-55296dfca12d",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "cluster.close()"
+   ]
   }
  ],
  "metadata": {
@@ -592,7 +624,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/threshold_tools_basics.ipynb
+++ b/threshold_tools_basics.ipynb
@@ -51,19 +51,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f909d7b9-b3fa-4f8e-bb97-39fb85eacf52",
-   "metadata": {
-    "scrolled": true,
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/OpenHydrology/lmoments3.git"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "1700f497-f85b-4d74-8150-1cfc32a9e4d9",
    "metadata": {
     "tags": []
@@ -207,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "subsetted_data = generated_data.sel(scenario='Historical Climate').sel(simulation='cnrm-esm2-1')\n",
+    "subsetted_data = generated_data.sel(scenario='Historical + SSP 3-7.0 -- Business as Usual').sel(simulation='cnrm-esm2-1')\n",
     "subsetted_data"
    ]
   },
@@ -503,7 +490,7 @@
    "source": [
     "## Step 5: Export\n",
     "\n",
-    "Use the below code to export a dataset as a NetCDF, GeoTIFF, or CSV file. Provide the name of the dataset in the environment to export as well as a character string containing the file name in quotations. If the dataset contains multiple variables, provide an argument specifying which variable to export (e.g. variable=”T2”). If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”)."
+    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset. "
    ]
   },
   {
@@ -517,14 +504,76 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4cb3a817-9313-49d0-9fac-ae4810f63110",
+   "metadata": {},
+   "source": [
+    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "3211a176-e026-463c-b479-05b8b735bf9d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.export_dataset(return_period,'my_filename')"
+    "app.export_dataset(return_period, 'my_filename')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "087c0d3d-e96d-4134-b37f-7c90db035154",
+   "metadata": {},
+   "source": [
+    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
+    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
+    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
+    "- GeoTIFF can accept 3 dimensions total:\n",
+    "    - X and Y dimensions are required\n",
+    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
+    "    - Metadata will be accessible as \"tags\" in the .tif\n",
+    "    \n",
+    "To export as a GeoTIFF or CSV file, please susbet the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c042aac6-980e-4b66-b3b0-eaa2f9179e7a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "return_period_variable = return_period['return_period']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebccea83-07bf-41d6-b263-9aa137861b3f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.export_as()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7662a3c-be83-41d7-b65f-1ce968fc99d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.export_dataset(return_period_variable, 'my_filename')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a863707-9f75-4feb-ad2e-1dc31a050a9a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -543,7 +592,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Splitting PRs per notebook, so apologies in advance for the multiple review requests.

This PR updates our threshold basics notebook for export and removed an unnecessary import.

To test:

1. Run through notebook
2. Check that export works for the thresholds data as a:
- **netcdf**
- **csv**
- **GeoTIFF** will work as long as there is some prior subsetting (example is provided of this, but if there is a clearer example that could be substituted here).