### PR TITLE
Notebook update: Threshold Application Example (Nabig)

### DIFF
--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -49,18 +49,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "627b7fad-86f3-484b-9ff5-d11631fe575c",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!pip install git+https://github.com/OpenHydrology/lmoments3.git"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "470105c8-f8d9-4291-843c-9a450da097e9",
    "metadata": {
     "tags": []
@@ -69,6 +57,21 @@
    "source": [
     "import climakitae as ck\n",
     "from climakitae import threshold_tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d002c171-4832-4faa-a6e7-1219431b4f65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import progress\n",
+    "from dask_gateway import GatewayCluster\n",
+    "cluster = GatewayCluster()\n",
+    "cluster.adapt(minimum=0, maximum=16)\n",
+    "client = cluster.get_client()\n",
+    "cluster"
    ]
   },
   {
@@ -121,9 +124,10 @@
     "For this section, please select:\n",
     "- \"daily\" timescale,\n",
     "- \"2m Air Temperature\",\n",
+    "- \"degC\" for units,\n",
     "- \"9 km\" resolution,\n",
     "- \"SSP3-7.0 -- Business as Usual\" scenario with \"Append historical\",\n",
-    "- and \"Ca counties\" area subset with \"Scramento County\" cached area."
+    "- and \"CA counties\" area subset with \"Scramento County\" cached area."
    ]
   },
   {
@@ -161,33 +165,6 @@
    "source": [
     "sacramento_ds = app.retrieve()\n",
     "sacramento_ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "992b35bb-d53f-40c6-9434-d334e1ab66c3",
-   "metadata": {},
-   "source": [
-    "#### Convert default units to desired units"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0c29f099-5bcb-441f-b247-84b2180143dd",
-   "metadata": {},
-   "source": [
-    "Note: Unit conversions are set to be built as a capability into *climakitae* package, so eventually manual coded conversions will not be necessary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d2b2e56e-0be8-46b7-8f04-42e51a3bde8b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sacramento_ds.data = sacramento_ds.data - 273.15\n",
-    "sacramento_ds.attrs['units'] = '˚C'"
    ]
   },
   {
@@ -694,6 +671,7 @@
     "For this section, please select:\n",
     "- \"daily\" timescale,\n",
     "- \"2m Air Temperature\",\n",
+    "- \"degC\" for units,\n",
     "- \"9 km\" resolution,\n",
     "- \"SSP3-7.0 -- Business as Usual\" scenario with \"Append historical\",\n",
     "- and \"states\" area subset with \"CA\" cached area."
@@ -740,33 +718,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74bfd130-dd0f-49ff-ae5b-bf6834b39a26",
-   "metadata": {},
-   "source": [
-    "#### Convert default units to desired units"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0006ccbd-262b-40fe-b313-2e78accf2654",
-   "metadata": {},
-   "source": [
-    "Note: Unit conversions are set to be built as a capability into *climakitae* package, so eventually manual coded conversions will not be necessary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1a0da98-dbd0-436c-9c5c-6ab2c3930d51",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_ds.data = ca_ds.data - 273.15\n",
-    "ca_ds.attrs['units'] = '˚C'"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "fdd2003b-a588-48b0-ba9a-1b7225e1b147",
    "metadata": {},
    "source": [
@@ -804,10 +755,6 @@
    "execution_count": null,
    "id": "c59576fb-c7af-4476-97fc-ad610d987c71",
    "metadata": {
-    "collapsed": true,
-    "jupyter": {
-     "outputs_hidden": true
-    },
     "tags": []
    },
    "outputs": [],
@@ -1123,7 +1070,7 @@
    "id": "6e2d8b88-ad5f-419e-b015-c473434fe9cc",
    "metadata": {},
    "source": [
-    "Use the below code to export a dataset as a NetCDF, GeoTIFF, or CSV file."
+    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset."
    ]
   },
   {
@@ -1143,7 +1090,54 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.export_dataset(return_period,'my_filename')"
+    "app.export_dataset(return_period, 'my_filename')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a44904c5-21c6-4643-a78b-d4fecf7cb899",
+   "metadata": {},
+   "source": [
+    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
+    "\n",
+    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
+    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
+    "- GeoTIFF can accept 3 dimensions total:\n",
+    "    - X and Y dimensions are required\n",
+    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
+    "    - Metadata will be accessible as \"tags\" in the .tif\n",
+    "    \n",
+    "To export as a GeoTIFF or CSV file, please susbet the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7297dd7-53da-4fbf-b52f-3a2fddf85a68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "return_period_variable = return_period['return_period']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7dfe587-55c8-4e3e-b163-5c14439b6816",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.export_as()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d2c0049-c530-465e-a051-88b35809c92e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.export_dataset(return_period_variable, 'my_filename')"
    ]
   }
  ],

--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -1070,7 +1070,13 @@
    "id": "6e2d8b88-ad5f-419e-b015-c473434fe9cc",
    "metadata": {},
    "source": [
-    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset."
+    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset.\n",
+    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
+    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
+    "- GeoTIFF can accept 3 dimensions total:\n",
+    "    - X and Y dimensions are required\n",
+    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
+    "    - Metadata will be accessible as \"tags\" in the .tif"
    ]
   },
   {
@@ -1095,49 +1101,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a44904c5-21c6-4643-a78b-d4fecf7cb899",
+   "id": "5d18bc3b-27b4-4add-a9d5-b70754879551",
    "metadata": {},
    "source": [
-    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
-    "\n",
-    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
-    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions total:\n",
-    "    - X and Y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif\n",
-    "    \n",
-    "To export as a GeoTIFF or CSV file, please susbet the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work):"
+    "Lastly, when you are done, close your cluster resources to free them up for the next time you work. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7297dd7-53da-4fbf-b52f-3a2fddf85a68",
+   "id": "85308419-809a-4d79-91e3-f02c5ae541dc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "return_period_variable = return_period['return_period']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7dfe587-55c8-4e3e-b163-5c14439b6816",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "app.export_as()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d2c0049-c530-465e-a051-88b35809c92e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "app.export_dataset(return_period_variable, 'my_filename')"
+    "cluster.close()"
    ]
   }
  ],

--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -127,7 +127,7 @@
     "- \"degC\" for units,\n",
     "- \"9 km\" resolution,\n",
     "- \"SSP3-7.0 -- Business as Usual\" scenario with \"Append historical\",\n",
-    "- and \"CA counties\" area subset with \"Scramento County\" cached area."
+    "- and \"CA counties\" area subset with \"Sacramento County\" cached area."
    ]
   },
   {

--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -122,8 +122,8 @@
    "metadata": {},
    "source": [
     "For this section, please select:\n",
-    "- \"daily\" timescale,\n",
-    "- \"2m Air Temperature\",\n",
+    "- \"monthly\" timescale,\n",
+    "- \"Air Temperature at 2m\",\n",
     "- \"degC\" for units,\n",
     "- \"9 km\" resolution,\n",
     "- \"SSP3-7.0 -- Business as Usual\" scenario with \"Append historical\",\n",
@@ -641,424 +641,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d86bbde-7f1a-4ce8-a3d2-3687fbf914c4",
-   "metadata": {},
-   "source": [
-    "## Threshold Advanced: Exploring Variations Statewide"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "11a7873c-9097-4dc8-839e-b514bc61cbb8",
-   "metadata": {},
-   "source": [
-    "### Step 1: Select"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b0805a5e-6e59-43cc-aafd-9a19d9c484e5",
-   "metadata": {},
-   "source": [
-    "#### Call *select* to display an interface from which to select the data to examine"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "83fec2e7-e0ee-4894-a0b4-4b8f02213cf1",
-   "metadata": {},
-   "source": [
-    "For this section, please select:\n",
-    "- \"daily\" timescale,\n",
-    "- \"2m Air Temperature\",\n",
-    "- \"degC\" for units,\n",
-    "- \"9 km\" resolution,\n",
-    "- \"SSP3-7.0 -- Business as Usual\" scenario with \"Append historical\",\n",
-    "- and \"states\" area subset with \"CA\" cached area."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "472d7795-c2dc-4792-b4e5-34b5ad9a57d1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "app.select()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e5014065-7f5a-4bab-a6ff-854c5c7bf515",
-   "metadata": {},
-   "source": [
-    "### Step 2: Retrieve"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "35a083ca-15a8-45f4-9fe2-3f7f4919fa88",
-   "metadata": {},
-   "source": [
-    "#### Call *app.retrieve()* to load the subset/combo of data specified"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "24981305-fcbd-47c4-89aa-1a246931e925",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "ca_ds = app.retrieve()\n",
-    "ca_ds"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fdd2003b-a588-48b0-ba9a-1b7225e1b147",
-   "metadata": {},
-   "source": [
-    "#### Subset data by scenario and simulation to prepare it for *threshold_tools* functions"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aa95ef65-38a6-46ca-85bf-4ed474c74c4f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_da = ca_ds.sel(simulation='cnrm-esm2-1')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8d44dd5e-d598-4e33-9f36-39b553ac4e14",
-   "metadata": {},
-   "source": [
-    "### Step 3: Transform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f9bb4d08-c701-4656-8961-3b703a95af40",
-   "metadata": {},
-   "source": [
-    "#### Pull Annual Maximum Series (AMS) for all grid cells"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c59576fb-c7af-4476-97fc-ad610d987c71",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "ca_ams = threshold_tools.get_ams(ca_da, extremes_type='max')\n",
-    "ca_ams = ca_ams.compute()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "83ac1891-f748-4922-8363-8b663e103877",
-   "metadata": {},
-   "source": [
-    "#### Subset data by time to prepare it for specific application"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d38e3922-f66a-42a2-816a-458966838da9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_1980_ams = ca_ams.sel(time=slice('1980-01-01', '2010-01-01'))\n",
-    "ca_2020_ams = ca_ams.sel(time=slice('2020-01-01', '2050-01-01'))\n",
-    "ca_2050_ams = ca_ams.sel(time=slice('2050-01-01', '2080-01-01'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "829908e1-be8e-473a-af07-a13d2b4b077f",
-   "metadata": {},
-   "source": [
-    "#### Calculate return value for a selected return period"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ddda2b6e-d14a-42fe-83fe-9fe5c0232e0c",
-   "metadata": {},
-   "source": [
-    "<span style=\"color:#E47704\">\n",
-    "    \n",
-    "**Application Example:** A electric utility planning on building new electrical eqiupment across California wants to calculate the value of a 1-in-20-year extreme temperature event that occured historically (during the 1980-2010 time period) and will occur in the future (during the 2020-50 and 2050-80 time periods) to ensure:\n",
-    "- they can build planned equipment in areas where the equipment does have the appropriate design standards to withstand extreme temperature events in the future,\n",
-    "- and to update the design standards for any future equipment built so that it can account for the range of extreme temperature events across the state."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16b1e3fb-15b5-491d-94fa-fa86002bf866",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_1980_rv = threshold_tools.get_return_value(ca_1980_ams, return_period=20,\n",
-    "                                              distr='gev', bootstrap_runs=100, \n",
-    "                                              conf_int_lower_bound=2.5, \n",
-    "                                              conf_int_upper_bound=97.5, \n",
-    "                                              multiple_points=True)\n",
-    "ca_1980_rv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e9a60b41-7ee6-4d8c-b381-177683936bb1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_2020_rv = threshold_tools.get_return_value(ca_2020_ams, return_period=20,\n",
-    "                                              distr='gev', bootstrap_runs=100, \n",
-    "                                              conf_int_lower_bound=2.5, \n",
-    "                                              conf_int_upper_bound=97.5, \n",
-    "                                              multiple_points=True)\n",
-    "ca_2020_rv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "67e3d6f5-fd57-437c-b94c-78ec3f229c74",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_2050_rv = threshold_tools.get_return_value(ca_2050_ams, return_period=20,\n",
-    "                                              distr='gev', bootstrap_runs=100, \n",
-    "                                              conf_int_lower_bound=2.5, \n",
-    "                                              conf_int_upper_bound=97.5, \n",
-    "                                              multiple_points=True)\n",
-    "ca_2050_rv"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f2e79e74-a508-4de1-a640-2793810c188e",
-   "metadata": {},
-   "source": [
-    "#### Apply a filter to showcase which areas of California exceed a certain return value"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7dca5f3e-bdcc-48fd-b8c2-ef0e4fce6f28",
-   "metadata": {},
-   "source": [
-    "<span style=\"color:#E47704\">\n",
-    "    \n",
-    "**Application Example:** A electric utility is worried about the climate impacts to their solar farms statewide given their current design standards and wants to evaluate those standards for any existing solar farms and update design standards for any future ones. \n",
-    "    \n",
-    "Their solar farms are made up of crystalline silicon solar cells, which undergo power decreases when ambient air temperature exceeds 25 degrees C (output decreases by 0.66% per 1 degrees C above that threshold).\n",
-    "    \n",
-    "In order to evaluate and update design standards, they want to look at the value of a 1-in-20-year extreme temperature event that will exceeds 40.15 deggrees C (corresponding to a 10% decrease in power output) both historically (during the 1980-2010 time period) and into the future (during the 2020-50 and 2050-80 time periods)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ed88b620-92b9-4c78-99f6-4beda5bdba68",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_1980_rv_filtered = ca_1980_rv.where(ca_1980_rv.return_value >= 40.15)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0bd20e6a-22b7-4aee-b5a1-72938d449bcf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_2020_rv_filtered = ca_2020_rv.where(ca_2020_rv.return_value >= 40.15)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f8f5f509-c399-49e0-acf4-c36432d2eb87",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_2050_rv_filtered = ca_2050_rv.where(ca_2050_rv.return_value >= 40.15)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "691fd897-9f95-425b-9ada-5bc6b607c949",
-   "metadata": {},
-   "source": [
-    "#### Calculate return period for a selected return value"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8a8a0bd9-9e94-4c6b-a282-21c852746e9a",
-   "metadata": {},
-   "source": [
-    "<span style=\"color:#E47704\">\n",
-    "    \n",
-    "**Application Example:** An electric utility with existing electrical infrastructure across California wants to calculate the return period of a 44 degrees C temperature event that occured historically (during the 1980-2010 time period) and will occur in the future (during the 2020-50 and 2050-80 time periods) to understand:\n",
-    "- what areas with existing infrastructure will be impacted by more frequently occuring extreme temperature events in the future,\n",
-    "- and to complete a more robust asset-by-asset vulnerability assessment statewide.\n",
-    "    \n",
-    "For the utility, 33 degrees C (hypothetically) repersents a state-wide historic average for a 1-in-20-year extreme temperature event (during the 1980-2010 time period)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "21c3781b-11a6-4657-a5ce-c0f002029f66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_1980_rp = threshold_tools.get_return_period(ca_1980_ams, return_value=33,\n",
-    "                                               distr='gev', bootstrap_runs=100, \n",
-    "                                               conf_int_lower_bound=2.5, \n",
-    "                                               conf_int_upper_bound=97.5, \n",
-    "                                               multiple_points=True)\n",
-    "ca_1980_rp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ac03067e-f8d7-4858-aa70-cefd9099a429",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_2020_rp = threshold_tools.get_return_period(ca_2020_ams, return_value=33,\n",
-    "                                               distr='gev', bootstrap_runs=100, \n",
-    "                                               conf_int_lower_bound=2.5, \n",
-    "                                               conf_int_upper_bound=97.5, \n",
-    "                                               multiple_points=True)\n",
-    "ca_2020_rp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c619bd01-a782-4d2f-b5de-36880410d6d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ca_2050_rp = threshold_tools.get_return_period(ca_2050_ams, return_value=33,\n",
-    "                                               distr='gev', bootstrap_runs=100, \n",
-    "                                               conf_int_lower_bound=2.5, \n",
-    "                                               conf_int_upper_bound=97.5, \n",
-    "                                               multiple_points=True)\n",
-    "ca_2050_rp"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "53cb91c2-a3fe-47f6-a60b-80fdd381a7d0",
-   "metadata": {},
-   "source": [
-    "### Step 4: Visualize"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2864b53e-7253-45a8-a12a-127df4e5066b",
-   "metadata": {},
-   "source": [
-    "#### Visualize return value"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a6e2482-5b35-4a60-8a17-bc8c352876d9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "threshold_tools.get_geospatial_plot(ca_1980_rv_filtered, data_variable='return_value',\n",
-    "                                    bar_min=44, bar_max=50)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5a233a61-c146-4df2-a1f6-4c804c69725f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "threshold_tools.get_geospatial_plot(ca_2020_rv_filtered, data_variable='return_value',\n",
-    "                                    bar_min=44, bar_max=50)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "41b8e319-bb1b-44e9-8705-66d4adc27601",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "threshold_tools.get_geospatial_plot(ca_2050_rv_filtered, data_variable='return_value',\n",
-    "                                    bar_min=44, bar_max=50)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "32d6aa65-12e8-4a9f-ab7c-87b2589fc066",
-   "metadata": {},
-   "source": [
-    "#### Visualize return period"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f9b21ba8-06bd-4fe2-9b3c-21540785d117",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "threshold_tools.get_geospatial_plot(ca_1980_rp, data_variable='return_period',\n",
-    "                                    bar_min=1, bar_max=100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aff34832-0711-4eb1-9dea-2d8b4b93f272",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "threshold_tools.get_geospatial_plot(ca_2020_rp, data_variable='return_period',\n",
-    "                                    bar_min=1, bar_max=100)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3680ca2b-af9b-49fc-b8cb-c2bbe03470d5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "threshold_tools.get_geospatial_plot(ca_2050_rp, data_variable='return_period',\n",
-    "                                    bar_min=1, bar_max=100)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "34b92acb-2cec-400b-8207-ba22d8a6ec9c",
    "metadata": {},
    "source": [
@@ -1070,7 +652,16 @@
    "id": "6e2d8b88-ad5f-419e-b015-c473434fe9cc",
    "metadata": {},
    "source": [
-    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset. "
+    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset. \n",
+    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
+    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
+    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
+    "- GeoTIFF can accept 3 dimensions total:\n",
+    "    - X and Y dimensions are required\n",
+    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
+    "    - Metadata will be accessible as \"tags\" in the .tif\n",
+    "\n",
+    "To export as a GeoTIFF or CSV file, please susbet the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work)."
    ]
   },
   {
@@ -1103,19 +694,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bd78de1f-404b-4af4-9fd2-b61be98ba214",
+   "id": "d3006556-0451-4b43-b91c-700ff195f765",
    "metadata": {},
    "source": [
-    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
-    "\n",
-    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
-    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions total:\n",
-    "    - X and Y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif\n",
-    "    \n",
-    "To export as a GeoTIFF or CSV file, please susbet the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work):"
+    "An example of subsetting is below, for exporting to a CSV or GeoTIFF."
    ]
   },
   {
@@ -1125,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ca_2050_rp_variable = ca_2050_rp['return_period']"
+    "sacramento_1980_rp_variable = sacramento_1980_rp['return_period']"
    ]
   },
   {
@@ -1145,7 +727,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.export_dataset(ca_2050_rp_variable, 'my_filename')"
+    "app.export_dataset(sacramento_1980_rp_variable, 'my_filename')"
    ]
   },
   {

--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -1070,13 +1070,7 @@
    "id": "6e2d8b88-ad5f-419e-b015-c473434fe9cc",
    "metadata": {},
    "source": [
-    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset.\n",
-    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
-    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions total:\n",
-    "    - X and Y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif"
+    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset. "
    ]
   },
   {
@@ -1090,13 +1084,68 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "7d0a91c7-9807-45b0-bb5e-698c812d139a",
+   "metadata": {},
+   "source": [
+    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "3871e445-dd02-4b4f-bf0e-a998278e917d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.export_dataset(return_period, 'my_filename')"
+    "app.export_dataset(ca_2050_rp, 'my_filename')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd78de1f-404b-4af4-9fd2-b61be98ba214",
+   "metadata": {},
+   "source": [
+    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
+    "\n",
+    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
+    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
+    "- GeoTIFF can accept 3 dimensions total:\n",
+    "    - X and Y dimensions are required\n",
+    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
+    "    - Metadata will be accessible as \"tags\" in the .tif\n",
+    "    \n",
+    "To export as a GeoTIFF or CSV file, please susbet the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "716b189a-6b5b-4638-bec6-b74e59fb80aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ca_2050_rp_variable = ca_2050_rp['return_period']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3309857-e9bc-4fb5-8034-deb9baff73d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.export_as()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04467a47-2b4c-4c02-b2da-e74082a8be9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app.export_dataset(ca_2050_rp_variable, 'my_filename')"
    ]
   },
   {


### PR DESCRIPTION
Splitting PRs per notebook, so apologies in advance for the multiple review requests.

This PR updates our threshold application example notebook for the following: 
- Updated markdown for unit selection, as this is now captured in climakitae and does not need to be manually computed
- Updated export
- Included a cluster call to help speed things up (I am not sure how well this helps though, since some steps do still take minutes to compute)

To test:

1. Run through notebook -- _Note: I am **only** able to get this notebook to run when **monthly** data is selected not daily. This may need to be an additional update for notebook viability_
2. Check that export works for the thresholds data as a:
- netcdf
- csv
- GeoTIFF will work as long as there is some prior subsetting (example is provided of this, but if there is a clearer example that could be substituted here).