### PR TITLE
add links to AE site docs

### DIFF
--- a/explore_amy.ipynb
+++ b/explore_amy.ipynb
@@ -67,7 +67,7 @@
    "id": "bcd8743c-ff16-4c8c-8b64-29d25cc358b9",
    "metadata": {},
    "source": [
-    "Additionally, get set up to make the computing go faster, by executing the following cell. It will likely take several minutes to spin up!"
+    "Additionally, get set up to make the computing go faster by executing the following cell. It will likely take several minutes to spin up! Learn more about dask and see some common [troubleshooting tips on our FAQ page](https://analytics.cal-adapt.org/docs/faq/)."
    ]
   },
   {
@@ -157,7 +157,9 @@
     "- Computation Options: Warming Level Future\n",
     "- Warming level of your own choosing\n",
     "\n",
-    "**Note**: Once you have selected the options you would like to investigate, please select the \"Reload Data\" button. It will take 3-5 minutes to update, hang tight!"
+    "**Note**: Once you have selected the options you would like to investigate, please select the \"Reload Data\" button. It will take 3-5 minutes to update, hang tight!\n",
+    "\n",
+    "To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). "
    ]
   },
   {
@@ -397,7 +399,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -474,7 +474,7 @@
    "id": "59d2cc2a-e77f-4b1f-b226-d224d97be98b",
    "metadata": {},
    "source": [
-    "Additionally, get set up to make the computing go faster, by executing this cell:"
+    "Additionally, get set up to make the computing go faster by executing the following cell. Learn more about dask and see some common [troubleshooting tips on our FAQ page](https://analytics.cal-adapt.org/docs/faq/)."
    ]
   },
   {
@@ -526,7 +526,9 @@
     "\n",
     "Simulations of high emissions scenarios will generally reach a given warming level faster than simulations of lower emissions scenarios.\n",
     "\n",
-    "The bottom panel shows regional responses of the variable of interest for the selected warming level for each individual model simulation. You can also see an average, minimum, and maximum regional response across simulations. "
+    "The bottom panel shows regional responses of the variable of interest for the selected warming level for each individual model simulation. You can also see an average, minimum, and maximum regional response across simulations. \n",
+    "\n",
+    "To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). "
    ]
   },
   {
@@ -785,7 +787,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -67,7 +67,9 @@
     "\n",
     "“Historical Climate” includes data from 1980-2014 simulated from the same GCMs used to produce the SSPs. They can be appended to a SSP time series using the option “Append historical.” Because this historical data is obtained through simulations, it represents average weather during the historical period and is not meant to capture historical timeseries as they occurred. \n",
     "\n",
-    "“Historical Reconstruction” provides a reference downscaled [reanalysis](https://www.ecmwf.int/en/about/media-centre/focus/2020/fact-sheet-reanalysis) dataset based on atmospheric models fit to satellite and station observations, and as a result will reflect observed historical time-evolution of the weather.\n"
+    "“Historical Reconstruction” provides a reference downscaled [reanalysis](https://www.ecmwf.int/en/about/media-centre/focus/2020/fact-sheet-reanalysis) dataset based on atmospheric models fit to satellite and station observations, and as a result will reflect observed historical time-evolution of the weather.\n",
+    "\n",
+    "To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). "
    ]
   },
   {
@@ -277,7 +279,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -60,6 +60,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f6bc3e86",
+   "metadata": {},
+   "source": [
+    "Additionally, get set up to make the computing go faster by executing the following cell. Learn more about dask and see some common [troubleshooting tips on our FAQ page](https://analytics.cal-adapt.org/docs/faq/)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "d002c171-4832-4faa-a6e7-1219431b4f65",
@@ -127,7 +135,9 @@
     "- \"degC\" for units,\n",
     "- \"9 km\" resolution,\n",
     "- \"SSP3-7.0 -- Business as Usual\" scenario with \"Append historical\",\n",
-    "- and \"CA counties\" area subset with \"Sacramento County\" cached area."
+    "- and \"CA counties\" area subset with \"Sacramento County\" cached area.\n",
+    "\n",
+    "To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). "
    ]
   },
   {
@@ -765,7 +775,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/threshold_tools_basics.ipynb
+++ b/threshold_tools_basics.ipynb
@@ -68,7 +68,7 @@
    "id": "0444b879-9e3c-4ba2-a830-57e36c88a30b",
    "metadata": {},
    "source": [
-    "Additionally, get set up to make the computing go faster, by executing the following cell. It may take a minute or two to spin up!"
+    "Additionally, get set up to make the computing go faster, by executing the following cell. It may take a minute or two to spin up! Learn more about dask and see some common [troubleshooting tips on our FAQ page](https://analytics.cal-adapt.org/docs/faq/)."
    ]
   },
   {
@@ -131,7 +131,9 @@
     "Note:\n",
     "- This version only offers the dynamically-downscaled data.\n",
     "- To streamline later analysis, it's helpful to select just one scenario.\n",
-    "- If you select 'daily' for 'Timescale' it will result in a daily average of the hourly data."
+    "- If you select 'daily' for 'Timescale' it will result in a daily average of the hourly data.\n",
+    "\n",
+    "To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). "
    ]
   },
   {
@@ -624,7 +626,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -46,7 +46,7 @@
    "id": "54b4b6bf-8949-4155-ac6d-e9a686347278",
    "metadata": {},
    "source": [
-    "Additionally, get set up to make the computing go faster, by executing this cell:"
+    "Additionally, get set up to make the computing go faster by executing the following cell. Learn more about dask and see some common [troubleshooting tips on our FAQ page](https://analytics.cal-adapt.org/docs/faq/)."
    ]
   },
   {
@@ -79,7 +79,9 @@
    "metadata": {},
    "source": [
     "## Step 1: Select\n",
-    "Be sure to select \"Append historical\" and \"Area average\" in order to work with the timeseries tools."
+    "Be sure to select \"Append historical\" and \"Area average\" in order to work with the timeseries tools.\n",
+    "\n",
+    "To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). "
    ]
   },
   {
@@ -282,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I added a link to the data catalog to each notebook to go along with the select or explore panel that reads:

> To learn more about the data available on the Analytics Engine, [see our data catalog](https://analytics.cal-adapt.org/data/). 

To all notebooks with a dask cluster, I added the following sentence:

> Additionally, get set up to make the computing go faster by executing the following cell. Learn more about dask and see some common [troubleshooting tips on our FAQ page](https://analytics.cal-adapt.org/docs/faq/).
