### PR TITLE
Limit users to a single cluster

### DIFF
--- a/explore_amy.ipynb
+++ b/explore_amy.ipynb
@@ -77,8 +77,8 @@
    "outputs": [],
    "source": [
     "from dask.distributed import progress\n",
-    "from dask_gateway import GatewayCluster\n",
-    "cluster = GatewayCluster()\n",
+    "from climakitae.cluster import Cluster\n",
+    "cluster = Cluster()\n",
     "cluster.adapt(minimum=0, maximum=16)\n",
     "client = cluster.get_client()\n",
     "cluster"

--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -70,8 +70,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_gateway import GatewayCluster\n",
-    "cluster = GatewayCluster()\n",
+    "from climakitae.cluster import Cluster\n",
+    "cluster = Cluster()\n",
     "cluster.adapt(minimum=0, maximum=16)\n",
     "client = cluster.get_client()\n",
     "cluster"

--- a/threshold_tools_application_examples.ipynb
+++ b/threshold_tools_application_examples.ipynb
@@ -75,8 +75,8 @@
    "outputs": [],
    "source": [
     "from dask.distributed import progress\n",
-    "from dask_gateway import GatewayCluster\n",
-    "cluster = GatewayCluster()\n",
+    "from climakitae.cluster import Cluster\n",
+    "cluster = Cluster()\n",
     "cluster.adapt(minimum=0, maximum=16)\n",
     "client = cluster.get_client()\n",
     "cluster"

--- a/threshold_tools_basics.ipynb
+++ b/threshold_tools_basics.ipynb
@@ -78,8 +78,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_gateway import GatewayCluster\n",
-    "cluster = GatewayCluster()\n",
+    "from climakitae.cluster import Cluster\n",
+    "cluster = Cluster()\n",
     "cluster.adapt(minimum=0, maximum=16)\n",
     "client = cluster.get_client()\n",
     "cluster"

--- a/threshold_tools_exceedance.ipynb
+++ b/threshold_tools_exceedance.ipynb
@@ -54,8 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_gateway import GatewayCluster\n",
-    "cluster = GatewayCluster()\n",
+    "from climakitae.cluster import Cluster\n",
+    "cluster = Cluster()\n",
     "cluster.adapt(minimum=0, maximum=16)\n",
     "client = cluster.get_client()\n",
     "cluster"

--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -56,8 +56,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dask_gateway import GatewayCluster\n",
-    "cluster = GatewayCluster()\n",
+    "from climakitae.cluster import Cluster\n",
+    "cluster = Cluster()\n",
     "cluster.adapt(minimum=0, maximum=8)\n",
     "client = cluster.get_client()\n",
     "cluster"


### PR DESCRIPTION
Switch from using the `dask_gateway.GatewayCluster` to the climakitae `Cluster` which limits users to a single running cluster.