### PR TITLE
Minor min/max markdown improvements to timeseries notebook

### DIFF
--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_data = app.load(my_data)"
+    "my_data = my_data.compute()"
    ]
   },
   {
@@ -173,8 +173,8 @@
     "\n",
     "You may also choose to explore patterns in the minimum, maximum, or an extreme of your choice (defined by the percentile slider: e.g. temperatures above the 90th percentile)\n",
     "- If you choose to look at extremes, you can change the resampling window and period to assess how extreme a pattern is over a time period of your own choosing\n",
-    "    - For example, you may want to examine the extreme minimum value for each year, in which we would recommend selecting “min”, 1 for the window, and “years” for the resample period. \n",
-    "    - Likewise, if you were interested in the extreme maximum over a decade, you would select “max”, 10 for the window, and “years” for the period\n",
+    "    - For example, you may want to examine the annual minimum, in which we would recommend selecting “min”, 1 for the window, and “years” for the resample period. \n",
+    "    - Likewise, if you were interested in the decadal maximum, you would select “max”, 10 for the window, and “years” for the period\n",
     "\n",
     "Examples of climatological interest: \n",
     "- Hourly: Consider 6, 12, or 24 hour events\n",


### PR DESCRIPTION
Two minor word clean-up to the markdown in the timeseries notebook for clarity. 

"extreme minimum value for each year" --> "annual minimum"
"extreme maximum over a decade" --> "decadal maximum"