### PR TITLE
Minor update for warming_levels figure for new pangeo image

### DIFF
--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -281,11 +281,13 @@
    "outputs": [],
    "source": [
     "import cartopy.crs as ccrs\n",
+    "from climakitae.utils import _read_ae_colormap\n",
+    "cmap = _read_ae_colormap(cmap='ae_orange', cmap_hex=False)\n",
     "\n",
-    "gridded = plots.plot.pcolormesh('lon','lat', col='simulation',\n",
+    "gridded = plots.plot.pcolormesh(x='lon',y='lat', col='simulation',\n",
     "                     transform=ccrs.PlateCarree(),subplot_kws={'projection': ccrs.Orthographic(-100,40)},\n",
-    "                         figsize=[15,5],cmap='Reds')\n",
-    "for ax in gridded.axes.flat:\n",
+    "                         figsize=[15,5],cmap=cmap)\n",
+    "for ax in gridded.axs.flat:\n",
     "    ax.coastlines()\n",
     "    ax.scatter(power_plants.lon, power_plants.lat, transform=ccrs.PlateCarree(),s=0.2,c='k')"
    ]
@@ -373,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Small updates for the warming levels notebook: 
1. Explicitly sets x and y, otherwise it barks
2. Sets the colormap to ae_orange
3. Updates language from axes to axs so scatter points can be overlain (this is the biggest difference)

**Setting as a draft for now until we officially switch pangeo images**