### PR TITLE
Station 8760s

### DIFF
--- a/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
@@ -243,6 +243,8 @@
     "    to_return = y.sel(time=str(which_8760.year.values),simulation=which_8760.simulation.values)\n",
     "    # set time to the same generic calendar year regardless:\n",
     "    to_return['time'] = np.arange(1,8761)\n",
+    "    # drop the simulation coord \n",
+    "    to_return = to_return.drop(\"simulation\")\n",
     "    return to_return\n"
    ]
   },
@@ -283,7 +285,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "median_year.drop(['scenario','simulation']).hvplot()"
+    "median_year.drop(['scenario']).hvplot()"
    ]
   },
   {
@@ -401,7 +403,7 @@
     "median_year_array['hour'] = median_year_array['time.hour']\n",
     "median_year_array['dayofyear'] = median_year_array['time.dayofyear']\n",
     "\n",
-    "median_year_df = median_year_array.to_pandas().drop(['scenario','simulation'],axis=1) \n",
+    "median_year_df = median_year_array.to_pandas().drop(['scenario'],axis=1) \n",
     "median_year_df = median_year_df.pivot(index=\"dayofyear\", columns=\"hour\")\n",
     "median_year_df.columns.names = ['station', 'hour']"
    ]

--- a/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
@@ -73,11 +73,11 @@
    "metadata": {},
    "source": [
     "#### Now retrieve the data, storing it in a variable called 'data'.\n",
-    "The data that will be retrieved is being bias-corrected using historical observations at each station selected. \n",
+    "The data that will be retrieved is being bias-corrected using hourly historical observations at each station selected. \n",
     "\n",
     "The historical observations come from [HadISD](https://catalogue.ceda.ac.uk/uuid/f579035b3c954475922e4b13705a7669). \n",
     "\n",
-    "The bias-correction procedure happening behind-the-scenes is called [QDM](https://journals.ametsoc.org/view/journals/clim/28/17/jcli-d-14-00754.1.xml), which is designed to preserve trends while allowing for different biases across quantiles. \n",
+    "The bias-correction procedure happening behind-the-scenes is called Quantile Delta Mapping ([QDM](https://journals.ametsoc.org/view/journals/clim/28/17/jcli-d-14-00754.1.xml)), which is designed to preserve trends while allowing for different biases across quantiles. \n",
     "\n",
     "The notebook 'localization.ipynb' steps through the bias-correction in more detail if you wish to understand what is happening."
    ]
@@ -141,11 +141,15 @@
    "id": "47d1abf5-1991-4fd9-8344-af5d7925e3ab",
    "metadata": {},
    "source": [
-    "We could stop there, but let's do a little more. Now that we have hourly data to work with, we can *improve upon the constructed 8760's that had otherwise been in use!*\n",
+    "Now that we have hourly data to work with, we can create and sample from a pool of 8760's which have consistent and realistic time series properties, improving on stochastic sampling methods that had otherwise been in use.\n",
     "\n",
     "#### Sample the \"8760\" closest to the median\n",
     "\n",
-    "One way that you may wish to use this data is to examine \"8760's\", or entire years of hourly data. If you chose a wide range of years previously, you might want to now sub-select, for example, only a historical reference period."
+    "One way that you may wish to use this data is to examine \"8760's\", or entire years of hourly data. If you chose a wide range of years previously, you might want to now sub-select, for example, only a historical reference period.\n",
+    "\n",
+    "Two main reasons to choose only a historical period (for now in this notebook):\n",
+    "- the following steps do not correct for the trends in the data due to climate change, so the median will reflect when the median amount of climate change has happened, instead of a median year solely with respect to year-to-year variability\n",
+    "- if you max out on the number of years, subsequent steps may execute more slowly"
    ]
   },
   {
@@ -218,7 +222,7 @@
     "\n",
     "def get_difference_hour(y): \n",
     "    #for this hour, of this day of the year, the median across all 8760s:\n",
-    "    median = y.median()\n",
+    "    median = y.quantile(q=0.5)\n",
     "    #return the difference from that median for each 8760:\n",
     "    return np.abs(y - median)\n",
     "\n",
@@ -247,7 +251,9 @@
    "id": "89537493-42ba-450c-bece-3dce51be677c",
    "metadata": {},
    "source": [
-    "And apply it across all the stations in the dataset:"
+    "Note that you could replace the 0.5 quantile (or median) with some other quantile.\n",
+    "\n",
+    "Apply the above functions across all the stations in the dataset:"
    ]
   },
   {
@@ -302,7 +308,7 @@
     "import pandas as pd\n",
     "\n",
     "def median_by_hour(y):\n",
-    "    by_hour = y.groupby('time.hour').median('time')\n",
+    "    by_hour = y.groupby('time.hour').quantile(q=0.5)\n",
     "    generic_year_day = pd.to_datetime('1981'+str(y['time.month'].values[0]).zfill(2)+\n",
     "                                      str(y['time.day'].values[0]).zfill(2))\n",
     "    by_hour['time'] = pd.date_range(generic_year_day,periods=24,freq='H')\n",
@@ -459,7 +465,8 @@
     "    y='hour',\n",
     "    yticks=[(int(one_hour),to_PST(one_hour)) for one_hour in median_year_array.hour.values],\n",
     "    groupby='station',\n",
-    "    cmap='Reds'\n",
+    "    cmap='Reds',\n",
+    "    clabel=app.selections.variable +' ('+ app.selections.units +')',\n",
     ")"
    ]
   },
@@ -566,6 +573,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "38deea9b-8c89-41cd-81f9-f0455d0acd00",
+   "metadata": {},
+   "source": [
+    "We could make a couple more modifications specificly for those who might read such a table into R."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5747243b-cf11-4be9-b59f-a517dfcef631",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_table.columns.set_names(['station','simulation'],inplace=True)\n",
+    "data_table_for_R = data_table.T.reset_index().T\n",
+    "data_table_for_R.loc['station'] = [data_table_for_R.loc['station'][one].values[0].replace(' ','_') \n",
+    "                                   for one in data_table_for_R.loc['station']]\n",
+    "data_table_for_R = data_table_for_R.reset_index()\n",
+    "data_table_for_R"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "50cf0ebb-60dc-4b8e-a441-1f96e2231fb5",
    "metadata": {},
    "source": [
@@ -580,6 +610,24 @@
    "outputs": [],
    "source": [
     "data_table.to_csv('test_output.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "369a643a-de1b-4238-8be9-e99b0a17c4c1",
+   "metadata": {},
+   "source": [
+    "Or if you wanted the R-friendly version (note there's an extra header row):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f2ab15d-31d5-4be8-9d0d-97f3048cd32c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_table_for_R.to_csv('test_output_for_R.csv')"
    ]
   },
   {
@@ -601,6 +649,14 @@
     "table_back = pd.read_csv('test_output.csv',index_col=[0,1], header=[0,1])\n",
     "table_back"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72068689-6898-403c-a202-3077f096c96a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
@@ -141,7 +141,7 @@
    "id": "47d1abf5-1991-4fd9-8344-af5d7925e3ab",
    "metadata": {},
    "source": [
-    "We could stop there, but let's do a little more. \n",
+    "We could stop there, but let's do a little more. Now that we have hourly data to work with, we can *improve upon the constructed 8760's that had otherwise been in use!*\n",
     "\n",
     "#### Sample the \"8760\" closest to the median\n",
     "\n",


### PR DESCRIPTION
Adds the notebooks: 'station_8760s.ipynb', which does two things:

- Access and export hourly data at station locations (netCDF or csv)
- Examine the “8760’s” and find the one with the smallest distance from the median -- view this in several ways.

The latter demo's another way to think about a "typical" 8760, as for an hourly load forecast. 
