### PR TITLE
DFU: temperature PDF comparison notebok

### DIFF
--- a/specific_use_cases/DFU_work_in_progress/temperature_distributions.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/temperature_distributions.ipynb
@@ -1,0 +1,328 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5e608c90-0373-4b64-a998-fedb0e0a0260",
+   "metadata": {},
+   "source": [
+    "## Temperature Density Profiles"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72e15e7c-b317-4b93-8868-8c0b4fc8271f",
+   "metadata": {},
+   "source": [
+    "This notebook is an early attempt to replicate the daily minimum and maximum weather distribution profiles provided to us by the DFU.\n",
+    "\n",
+    "**Try plotting the daily min and max pdf’s for the WRF-BC’d-to-a-station data, on the same plot as the station data we use for bias-correction, to compare with a similar plot that DFU shared an excel workbook for**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fc90d21-de7c-4e46-8cf2-655b88ab9492",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import xarray as xr\n",
+    "import scipy.stats as stats\n",
+    "import calendar\n",
+    "import climakitae as ck\n",
+    "\n",
+    "pd.options.plotting.backend = 'holoviews'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b39158e-412e-4923-b537-ccf9547b2025",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "app = ck.Application()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6ca3cbc-6315-4fcc-9199-33d7e30c08ea",
+   "metadata": {},
+   "source": [
+    "### Step 1: Retrieve bias-corrected data for a station \n",
+    "\n",
+    "First we'll read in some **bias-corrected station data**. For ease of reproducibility, we have pre-loaded data selections for air temperature for the Burbank-Glendale-Pasadena Airport for 1985-2010. However, if you would like to make modifications, or see how the data can be selected, uncomment the line app.select in the cell below to pull up a useful panel that illustrates all of the data options."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e84435f8-6117-42e5-a601-966a68647b39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## preset location and data selections for ease here\n",
+    "\n",
+    "app.location.data_type = \"Station\"\n",
+    "app.location.station=['Burbank-Glendale-Pasadena Airport']\n",
+    "app.selections.variable = \"Air Temperature at 2m\"\n",
+    "app.selections.unit = \"degF\" \n",
+    "app.selections.resolution = \"3 km\"\n",
+    "app.selections.time_slice = (1985, 2010)\n",
+    "\n",
+    "# app.select()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f60226cd-b5b7-4b00-a45b-2415beb096c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = app.retrieve().squeeze() # retrieves the data, and drops any singleton dimensions (scenario, in this case)\n",
+    "data = app.load(data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69f0f27c-25a6-406d-8b50-fb13f738cd96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# examine the dataset for information\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d83fb00-1639-4c4b-82fc-565a4ba10158",
+   "metadata": {},
+   "source": [
+    "### Step 2: Calculate daily min and max temperatures distributions\n",
+    "\n",
+    "#### Step 2a: Calculate daily min and max temperaturees\n",
+    "As the bias corrected data is at an hourly scale, we will need to calculate the daily minimum and maximum values. We do this below using the built-in xarray function `resample` which identifies the maximum/minimum value in each 1 day period, and returns that value for every day as a collapsed daily time-series. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f96384bc-afa6-4c7d-ac5d-7499e15ff2cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t2_dailymax = data.resample(time=\"1D\").max() # daily maximum from hourly data\n",
+    "t2_dailymin = data.resample(time=\"1D\").min() # daily minimum from hourly data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bca4ded5-282b-4ea7-87d0-582f1a153571",
+   "metadata": {},
+   "source": [
+    "#### Step 2b: Calculate the probability distribution function for daily maximum and minimum temperature\n",
+    "\n",
+    "We'll do this with the scipy library function `stats.norm` with the `pdf` option, this ensures that we are calculating the probability density function. We've created a wrapper function `data_pdf` that does this for all the simulations available. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb4d12a0-ce06-4a13-bf46-5aa5609253b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def data_pdf(data, bins, ext):\n",
+    "    \"\"\"processes data to produce the pdf arrays\"\"\"\n",
+    "    \n",
+    "    # determines how many simulations we are working with\n",
+    "    num_sim = len(data.simulation.values)\n",
+    "    \n",
+    "    # set-up for first simulation\n",
+    "    data_sim = data.isel(simulation=0) # first simulation\n",
+    "    data_sim_arr = data_sim.to_array() # converts to a data-array, as stats can only be calculated on a single array at a time\n",
+    "    data_sim_mean, data_sim_std = data_sim_arr.mean(), data_sim_arr.std() # calculates the mean, standard deviation\n",
+    "    data_sim_snd = stats.norm(data_sim_mean.values, data_sim_std.values) # calculates normal distribution using mean and std. deviation\n",
+    "    data_pdf_arr = data_sim_snd.pdf(bins) # calculates the pdf\n",
+    "    \n",
+    "    # sets-up dataframe of pdf values, for easy plotting and export\n",
+    "    df = pd.DataFrame(data = data_pdf_arr, columns = [str(data_sim.simulation.values) + \"_\" + str(ext)])\n",
+    "    \n",
+    "    # same process for every other simulation\n",
+    "    for sim in range(1, num_sim):\n",
+    "        data_sim = data.isel(simulation=sim)\n",
+    "        data_sim_arr = data_sim.to_array()\n",
+    "        data_sim_i_mean, data_sim_i_std = data_sim_arr.mean(), data_sim_arr.std()\n",
+    "        data_sim_i_snd = stats.norm(data_sim_i_mean.values, data_sim_i_std.values) \n",
+    "        data_pdf_arr = data_sim_i_snd.pdf(bins)\n",
+    "        df[str(data_sim.simulation.values) + '_' + str(ext)] = data_pdf_arr # adds simulation name and max/min extension\n",
+    "                \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "05bfe215-4527-46de-b51c-d90d5b7ae230",
+   "metadata": {},
+   "source": [
+    "Next we set-up the number of bins to calculate the PDF over. We are interested in the range between 20°F and 120°F, at a 1°F interval. In the bins set-up, the high end of the range has a +1 included to ensure that 120 is the maximum here (and not 119). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d18fc79-5c3b-4c45-bca8-7c910e72d846",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lowest_temp = 20\n",
+    "highest_temp = 120\n",
+    "bins = np.arange(lowest_temp, highest_temp+1, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90eb921c-4df0-4ad9-b588-33e4fe8709c9",
+   "metadata": {},
+   "source": [
+    "Now, we calculate the PDF for a specific month. First, we need to grab just the data for that month, for which we've set-up the `grab_months` function, for which you can pass the month to, but be sure to pass a number to this function (Jan=1, Dec=12). We use February (month=2) as an example here, but you can modify the month to be any of your choosing. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34c9c2ec-dae4-4451-933f-f29c52a1c6bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def grab_months(data, month):\n",
+    "    \"\"\"Grabs the specific month of interest and returns DataSet of all years for that month.\n",
+    "    Month must be passed as a number\"\"\"\n",
+    "    data_months = data.groupby('time.month').groups\n",
+    "    month_idxs = data_months[month]\n",
+    "    return data.isel(time=month_idxs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d2028c8-a748-407f-9d17-b0723b69bc39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "month = 2 # default of February\n",
+    "t2_dailymax_monthly = grab_months(t2_dailymax, month=month)\n",
+    "t2_dailymin_monthly = grab_months(t2_dailymin, month=month)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "326b6e00-8824-475e-96ce-5978f1e41f05",
+   "metadata": {},
+   "source": [
+    "Calculate the daily PDFs for that month below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6cc7b707-c922-4895-a9aa-e1b2a8946b04",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maxtemp_pdf = data_pdf(t2_dailymax_monthly, bins=bins, ext='max')\n",
+    "mintemp_pdf = data_pdf(t2_dailymin_monthly, bins=bins, ext='min')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "443766e1-73a7-4456-9ca0-c1ba68a31d41",
+   "metadata": {},
+   "source": [
+    "Combine the dataframes together so that they are all in a single location, and can be easily visualized and exported to a .csv file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea61ef5d-f0b2-4266-8adc-e69f88abf784",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bins_df = pd.DataFrame(data=bins, columns=['Temperature'])\n",
+    "df_to_plot = pd.concat([bins_df, maxtemp_pdf, mintemp_pdf], axis=1, join=\"inner\")\n",
+    "df_to_plot = df_to_plot.set_index('Temperature')\n",
+    "df_to_plot.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bba75f25-5118-40d8-9b12-f4ebeed7018c",
+   "metadata": {},
+   "source": [
+    "#### Step 2c: Visualize the results\n",
+    "Plot distributions of daily maximum and minimum temperature for a selected month over a set of years. Remember, here we are using data from 1985-2010 as our baseline, and are displaying the results for February, but you can choose any month above! Play around with different months to see how the PDF distributions vary. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd450a03-11a8-40fa-936c-db03523fecdd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_to_plot.plot(xlabel=\"Temperature (degF)\",\n",
+    "                grid=True, # adds gridlines for easier interpretation\n",
+    "                title=\"PDFs for \" + str(app.location.station[0]) + \"\\n\" + calendar.month_name[month],\n",
+    "               )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9c1776f-e8cf-4db4-8cc1-7e4bd32985f4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Step 3: Export PDF values to a .csv file\n",
+    "Lastly, we'll export the dataframe of PDF values to a csv file. Included is the temperature bins, and the maximum and minimum PDF distributions per simulation. \n",
+    "- **QUESTION**: original spreadsheet has \"grand total\" = sum of each column? do we include this? "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2570c02-e6dc-4f8f-b5be-0dbc8bdcaefb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"temperature_pdfs_{0}.csv\".format(app.location.station[0].replace(\" \", \"_\")).lower()\n",
+    "df_to_plot.to_csv(filename, index=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/specific_use_cases/DFU_work_in_progress/temperature_distributions.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/temperature_distributions.ipynb
@@ -13,9 +13,7 @@
    "id": "72e15e7c-b317-4b93-8868-8c0b4fc8271f",
    "metadata": {},
    "source": [
-    "This notebook is an early attempt to replicate the daily minimum and maximum weather distribution profiles provided to us by the DFU.\n",
-    "\n",
-    "**Try plotting the daily min and max pdf’s for the WRF-BC’d-to-a-station data, on the same plot as the station data we use for bias-correction, to compare with a similar plot that DFU shared an excel workbook for**\n"
+    "This notebook is an early attempt to replicate the daily minimum and maximum weather distribution profiles provided to us by the DFU. In this notebook, we will calculate and compare the probability density functions between the observed weather station data and the bias-corrected downscaled data available on the Cal-Adapt: Analytics Engine. "
    ]
   },
   {
@@ -50,7 +48,7 @@
    "id": "d6ca3cbc-6315-4fcc-9199-33d7e30c08ea",
    "metadata": {},
    "source": [
-    "### Step 1: Retrieve bias-corrected data for a station \n",
+    "### Step 1: Retrieve bias-corrected downscaled data for a station\n",
     "\n",
     "First we'll read in some **bias-corrected station data**. For ease of reproducibility, we have pre-loaded data selections for air temperature for the Burbank-Glendale-Pasadena Airport for 1985-2010. However, if you would like to make modifications, or see how the data can be selected, uncomment the line app.select in the cell below to pull up a useful panel that illustrates all of the data options."
    ]
@@ -62,12 +60,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## preset location and data selections for ease here\n",
-    "\n",
     "app.location.data_type = \"Station\"\n",
     "app.location.station=['Burbank-Glendale-Pasadena Airport']\n",
     "app.selections.variable = \"Air Temperature at 2m\"\n",
-    "app.selections.unit = \"degF\" \n",
+    "app.selections.units = \"degF\" \n",
     "app.selections.resolution = \"3 km\"\n",
     "app.selections.time_slice = (1985, 2010)\n",
     "\n",
@@ -81,19 +77,102 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = app.retrieve().squeeze() # retrieves the data, and drops any singleton dimensions (scenario, in this case)\n",
-    "data = app.load(data)"
+    "bc_data = app.retrieve() # retrieves the bias-corrected data\n",
+    "bc_data # examine the dataset for information"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69f0f27c-25a6-406d-8b50-fb13f738cd96",
+   "id": "397e6abe-d4b1-42d5-9292-51376fe9307e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# examine the dataset for information\n",
-    "data"
+    "bc_data = app.load(bc_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81b00fcf-b559-4ea2-a6a4-4edbec7ef46c",
+   "metadata": {},
+   "source": [
+    "### Step 2: Retrieve the observed weather station data\n",
+    "Now we also grab the station data itself, in order to compare the difference between the raw weather station data and the downscaled data at that station. \n",
+    "\n",
+    "#### Step 2a: Identify the station data within the catalog\n",
+    "The station data is located in our catalog, for which we read in the `hadisd_stations.csv` file to identify the station of interest. We then use information about the station (like its name) to retrieve the exact path to grab the data. The following code cells normally occur \"behind the scenes\" in our data retrieval for station data, but here we utilize some of this code to illustrate the process of grabbing the observed station data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a27e28d3-c16c-4673-a1f4-62db2e862b4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from climakitae.data_loaders import _preprocess_hadisd\n",
+    "import pkg_resources\n",
+    "\n",
+    "stations = pkg_resources.resource_filename(\"climakitae\", \"data/hadisd_stations.csv\")\n",
+    "stations_df = pd.read_csv(stations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8777442-9218-4c46-85ba-e7d9450041af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "station_subset = stations_df.loc[stations_df[\"station\"].isin(app.location.station)]\n",
+    "filepaths = [\n",
+    "    \"s3://cadcat/tmp/hadisd/HadISD_{}.zarr\".format(s_id)\n",
+    "    for s_id in station_subset[\"station id\"]\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e43cc459-b1b6-4fe1-bf0a-9a494d2250d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# retrieve the data, and examine\n",
+    "station_ds = xr.open_mfdataset(\n",
+    "    filepaths,\n",
+    "    preprocess=_preprocess_hadisd,\n",
+    "    engine=\"zarr\",\n",
+    "    consolidated=False,\n",
+    "    parallel=True,\n",
+    "    backend_kwargs=dict(storage_options={\"anon\": True}),\n",
+    ")\n",
+    "\n",
+    "station_ds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a955878f-fdcf-49a5-ae84-53b62707f71d",
+   "metadata": {},
+   "source": [
+    "#### Step 2b: Pre-process the observed station data\n",
+    "The observed station data covers a much longer time period, and the units are natively in Kelvin. Therefore, in order to compare to the bias-corrected data, we slice the observed data to match the time period of intereset (1985 to 2010), and convert units to degrees Fahrenheit. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "246e72fa-79f1-4699-85a1-49e3cd41983d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# slice to match time frame\n",
+    "station_ds = station_ds.sel(time = slice('1985-01-01', '2010-12-31'))\n",
+    "\n",
+    "# convert units: data is in K, need to convert to degF for comparison\n",
+    "station_ds = (station_ds - 273.15) * (9/5) + 32.0\n",
+    "station_ds.attrs['units'] = 'degF'"
    ]
   },
   {
@@ -101,10 +180,12 @@
    "id": "4d83fb00-1639-4c4b-82fc-565a4ba10158",
    "metadata": {},
    "source": [
-    "### Step 2: Calculate daily min and max temperatures distributions\n",
+    "### Step 3: Calculate daily min and max temperatures distributions\n",
     "\n",
-    "#### Step 2a: Calculate daily min and max temperaturees\n",
-    "As the bias corrected data is at an hourly scale, we will need to calculate the daily minimum and maximum values. We do this below using the built-in xarray function `resample` which identifies the maximum/minimum value in each 1 day period, and returns that value for every day as a collapsed daily time-series. "
+    "#### Step 3a: Calculate daily min and max temperaturees\n",
+    "As both the observed station data and bias corrected data are at an hourly scale, we will need to calculate the daily minimum and maximum values. We do this below using the built-in xarray function `resample` which identifies the maximum/minimum value in each 1 day period, and returns that value for every day as a collapsed daily time-series. \n",
+    "\n",
+    "Note, the resampling may take 1-2 minutes, it's doing a lot of work at this step!"
    ]
   },
   {
@@ -114,8 +195,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t2_dailymax = data.resample(time=\"1D\").max() # daily maximum from hourly data\n",
-    "t2_dailymin = data.resample(time=\"1D\").min() # daily minimum from hourly data"
+    "# bias-corrected data\n",
+    "t2_dailymax = bc_data.resample(time=\"1D\").max() # daily maximum from hourly data\n",
+    "t2_dailymin = bc_data.resample(time=\"1D\").min() # daily minimum from hourly data\n",
+    "\n",
+    "# observed station data\n",
+    "obs_dailymax = station_ds.resample(time=\"1D\").max() # daily maximum from hourly data\n",
+    "obs_dailymin = station_ds.resample(time=\"1D\").min() # daily minimum from hourly data"
    ]
   },
   {
@@ -123,9 +209,9 @@
    "id": "bca4ded5-282b-4ea7-87d0-582f1a153571",
    "metadata": {},
    "source": [
-    "#### Step 2b: Calculate the probability distribution function for daily maximum and minimum temperature\n",
+    "#### Step 3b: Calculate the probability distribution function for daily maximum and minimum temperature\n",
     "\n",
-    "We'll do this with the scipy library function `stats.norm` with the `pdf` option, this ensures that we are calculating the probability density function. We've created a wrapper function `data_pdf` that does this for all the simulations available. "
+    "We'll do this with the scipy library function `stats.norm` with the `pdf` option, this ensures that we are calculating the probability density function. We've created a wrapper function `data_pdf` that does this for all the simulations available. Because the observed station data does not retain simulation data (of course!), we also have a companion wrapper function `obs_pdf` to calculate the PDFs for the observed station data too. "
    ]
   },
   {
@@ -136,7 +222,7 @@
    "outputs": [],
    "source": [
     "def data_pdf(data, bins, ext):\n",
-    "    \"\"\"processes data to produce the pdf arrays\"\"\"\n",
+    "    \"\"\"PDF processing for bias-corrected data, wth simulations\"\"\"\n",
     "    \n",
     "    # determines how many simulations we are working with\n",
     "    num_sim = len(data.simulation.values)\n",
@@ -160,6 +246,25 @@
     "        data_pdf_arr = data_sim_i_snd.pdf(bins)\n",
     "        df[str(data_sim.simulation.values) + '_' + str(ext)] = data_pdf_arr # adds simulation name and max/min extension\n",
     "                \n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aac8d1d8-492e-41bb-8e4c-03b995dadf60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def obs_pdf(obs_ds, bins, ext):\n",
+    "    \"\"\"PDF processing for observational data, no simulations\"\"\"\n",
+    "    data_arr = obs_ds.to_array()\n",
+    "    data_mean, data_std = data_arr.mean(), data_arr.std()\n",
+    "    data_snd = stats.norm(data_mean.values, data_std.values)\n",
+    "    data_pdf_arr = data_snd.pdf(bins)\n",
+    "    \n",
+    "    df = pd.DataFrame(data = data_pdf_arr, columns = [\"obs_\" + str(ext)])\n",
+    "    \n",
     "    return df"
    ]
   },
@@ -214,8 +319,14 @@
    "outputs": [],
    "source": [
     "month = 2 # default of February\n",
+    "\n",
+    "# bias-corrected data\n",
     "t2_dailymax_monthly = grab_months(t2_dailymax, month=month)\n",
-    "t2_dailymin_monthly = grab_months(t2_dailymin, month=month)"
+    "t2_dailymin_monthly = grab_months(t2_dailymin, month=month)\n",
+    "\n",
+    "# observed station data\n",
+    "obs_dailymax_monthly = grab_months(obs_dailymax, month=month)\n",
+    "obs_dailymin_monthly = grab_months(obs_dailymin, month=month)"
    ]
   },
   {
@@ -233,8 +344,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# bias-corrected data\n",
     "maxtemp_pdf = data_pdf(t2_dailymax_monthly, bins=bins, ext='max')\n",
-    "mintemp_pdf = data_pdf(t2_dailymin_monthly, bins=bins, ext='min')"
+    "mintemp_pdf = data_pdf(t2_dailymin_monthly, bins=bins, ext='min')\n",
+    "\n",
+    "# observed station data\n",
+    "obs_maxtemp_pdf = obs_pdf(obs_dailymax_monthly, bins=bins, ext='max')\n",
+    "obs_mintemp_pdf = obs_pdf(obs_dailymin_monthly, bins=bins, ext='min')"
    ]
   },
   {
@@ -253,9 +369,31 @@
    "outputs": [],
    "source": [
     "bins_df = pd.DataFrame(data=bins, columns=['Temperature'])\n",
-    "df_to_plot = pd.concat([bins_df, maxtemp_pdf, mintemp_pdf], axis=1, join=\"inner\")\n",
-    "df_to_plot = df_to_plot.set_index('Temperature')\n",
-    "df_to_plot.head()"
+    "df_obs_bc = pd.concat([bins_df, # temperature bins ranging between 20-120\n",
+    "                       obs_maxtemp_pdf, obs_mintemp_pdf, # observed max and min temp\n",
+    "                       maxtemp_pdf, mintemp_pdf, # bias-corrected downscaled data\n",
+    "                      ], axis=1, join=\"inner\")\n",
+    "df_obs_bc = df_obs_bc.set_index('Temperature')\n",
+    "df_obs_bc.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97704565-f87b-48d4-ad5b-3b842289a0d0",
+   "metadata": {},
+   "source": [
+    "We'll also export the dataframe of PDF values to a csv file. Included are the temperature bins and the maximum and minimum PDF distributions per simulation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ec21cd2-9102-4a8e-a46d-cc4798340c70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = \"temperature_pdfs_{0}_{1}.csv\".format(app.location.station[0].replace(\" \", \"_\"), calendar.month_abbr[month]).lower()\n",
+    "df_obs_bc.to_csv(filename, index=True)"
    ]
   },
   {
@@ -263,8 +401,10 @@
    "id": "bba75f25-5118-40d8-9b12-f4ebeed7018c",
    "metadata": {},
    "source": [
-    "#### Step 2c: Visualize the results\n",
-    "Plot distributions of daily maximum and minimum temperature for a selected month over a set of years. Remember, here we are using data from 1985-2010 as our baseline, and are displaying the results for February, but you can choose any month above! Play around with different months to see how the PDF distributions vary. "
+    "### Step 4: Visualize the results\n",
+    "We now plot the distributions of daily maximum and minimum temperature for a selected month over a set of years. Remember, here we are using data from 1985-2010 as our baseline, and are displaying the results for February, but you can choose any month above! Play around with different months to see how the PDF distributions vary. \n",
+    "\n",
+    "This plotting code cell may take 1-2 minutes to run -- hang tight!"
    ]
   },
   {
@@ -274,33 +414,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_to_plot.plot(xlabel=\"Temperature (degF)\",\n",
+    "df_obs_bc.plot(xlabel=\"Temperature (degF)\",\n",
     "                grid=True, # adds gridlines for easier interpretation\n",
-    "                title=\"PDFs for \" + str(app.location.station[0]) + \"\\n\" + calendar.month_name[month],\n",
+    "                title=\"PDFs for \" + str(app.location.station[0]) + \"\\n\" + calendar.month_name[month], # detailed title with station and month\n",
     "               )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e9c1776f-e8cf-4db4-8cc1-7e4bd32985f4",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "#### Step 3: Export PDF values to a .csv file\n",
-    "Lastly, we'll export the dataframe of PDF values to a csv file. Included is the temperature bins, and the maximum and minimum PDF distributions per simulation. \n",
-    "- **QUESTION**: original spreadsheet has \"grand total\" = sum of each column? do we include this? "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a2570c02-e6dc-4f8f-b5be-0dbc8bdcaefb",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "filename = \"temperature_pdfs_{0}.csv\".format(app.location.station[0].replace(\" \", \"_\")).lower()\n",
-    "df_to_plot.to_csv(filename, index=True)"
    ]
   }
  ],


### PR DESCRIPTION
This notebook reproduces an excel spreadsheet that calculates the PDF of daily max and min temperatures, by also comparing the bias-corrected downscaled data and the observed station data. Users are also able to export a csv of the resulting pdf distributions. 

Would love a "is this what DFU needs to answer their question" review, as well as a code-y review!

**Questions**
1. Do we want to have the "this is how you get the observed station data from the catalog" more or less prominent? 
2. In the spreadsheet, at the bottom of each of the PDF distributions per simulation, there was a "grand total", which is presumably a sum of the values. I haven't incorporated this, do/should we include?
3. A couple of new functions here could conceivably go into climakitae utils.py if we want to retain them