### PR TITLE
Modify simulation selection to match with LOCA catalog

### DIFF
--- a/explore_internal_variability.ipynb
+++ b/explore_internal_variability.ipynb
@@ -168,6 +168,7 @@
     "import xarray as xr\n",
     "import pandas as pd\n",
     "import numpy as np\n",
+    "import fnmatch\n",
     "import matplotlib.pyplot as plt\n",
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\")\n",
@@ -246,11 +247,13 @@
     "wrf_ds = app.retrieve().squeeze()\n",
     "\n",
     "cmip_names = ['CESM2', 'CNRM-ESM2-1', 'EC-Earth3-Veg', 'FGOALS-g3'] # Simulation names in CMIP6\n",
+    "wrf_cmip_lookup_dict = { # WRF simulation names have additional information about activity ID and ensemble \n",
+    "    # Lookup dictionary used to rename simulation values\n",
+    "    fnmatch.filter(wrf_ds.simulation.values, \"*{0}*\".format(cmip))[0]:cmip for cmip in cmip_names\n",
+    "}\n",
+    "\n",
     "wrf_ds = wrf_ds.sortby(\"simulation\") # Sort simulations alphabetically   \n",
-    "wrf_ds[\"simulation\"] = [ # Use CMIP6 simulations in WRF. \n",
-    "    sim for sim in cmip_names \n",
-    "    if sim+\"_WRF\" in wrf_ds.simulation.values # Rename simulations to match CMIP6 names \n",
-    "]\n",
+    "wrf_ds[\"simulation\"] = [wrf_cmip_lookup_dict[sim] for sim in wrf_ds.simulation.values] # Rename simulations \n",
     "wrf_ds = wrf_ds.clip(0.1) # Remove values less than 0.1"
    ]
   },
@@ -919,10 +922,7 @@
     "\n",
     "reg_wrf_ds = app.retrieve().squeeze()\n",
     "reg_wrf_ds = reg_wrf_ds.sortby(\"simulation\") # Sort simulations alphabetically   \n",
-    "reg_wrf_ds[\"simulation\"] = [ # Use CMIP6 simulations in WRF. \n",
-    "    sim for sim in cmip_names \n",
-    "    if sim+\"_WRF\" in reg_wrf_ds.simulation.values # Rename simulations to match CMIP6 names \n",
-    "]\n",
+    "reg_wrf_ds[\"simulation\"] = [wrf_cmip_lookup_dict[sim] for sim in reg_wrf_ds.simulation.values] # Rename simulations \n",
     "reg_wrf_ds = reg_wrf_ds.clip(0.1)"
    ]
   },
@@ -1135,10 +1135,7 @@
     "box_wrf_ds = app.retrieve().squeeze()\n",
     "\n",
     "box_wrf_ds = box_wrf_ds.sortby(\"simulation\") # Sort simulations alphabetically   \n",
-    "box_wrf_ds[\"simulation\"] = [ # Use CMIP6 simulations in WRF. \n",
-    "    sim for sim in cmip_names \n",
-    "    if sim+\"_WRF\" in box_wrf_ds.simulation.values # Rename simulations to match CMIP6 names \n",
-    "]\n",
+    "box_wrf_ds[\"simulation\"] = [wrf_cmip_lookup_dict[sim] for sim in box_wrf_ds.simulation.values] # Rename simulations \n",
     "box_wrf_ds = box_wrf_ds.clip(0.1) # Remove values less than 0.1"
    ]
   },


### PR DESCRIPTION
Needed to modify how the simulations are subsetted again since the naming of the simulations changed using app.retrieve() for the new data catalog structure. 

Test using climakitae branch `loca_ensemble`