### PR TITLE
replace location with selections

### DIFF
--- a/explore_amy.ipynb
+++ b/explore_amy.ipynb
@@ -264,7 +264,7 @@
     "lineplot_from_amy_data(\n",
     "    one_month, \n",
     "    computation_method=amy_selections.computation_method, # Historical or Warming Level Future  \n",
-    "    location_subset=app.location.cached_area, # Location subset information \n",
+    "    location_subset=app.selections.cached_area, # Location subset information \n",
     "    warmlevel=amy_selections.warmlevel, # Warming level selection \n",
     "    variable=app.selections.variable+\"(\"+app.selections.units+\")\" # Variable and units selected. \n",
     ")"

--- a/explore_internal_variability.ipynb
+++ b/explore_internal_variability.ipynb
@@ -240,9 +240,9 @@
     "app.selections.resolution = '9 km'\n",
     "app.selections.timescale = 'monthly'\n",
     "app.selections.downscaling_method = [\"Dynamical\"]\n",
-    "app.location.area_subset = 'states'\n",
-    "app.location.cached_area = 'CA'\n",
-    "app.location.area_average = 'No'\n",
+    "app.selections.area_subset = 'states'\n",
+    "app.selections.cached_area = 'CA'\n",
+    "app.selections.area_average = 'No'\n",
     "\n",
     "wrf_ds = app.retrieve().squeeze()\n",
     "\n",
@@ -556,7 +556,7 @@
    "outputs": [],
    "source": [
     "hist_cae_ds, warm_cae_ds = get_ensemble_data(\n",
-    "    variable=copt.variable, location=app.location, cmip_names=cmip_names)"
+    "    variable=copt.variable, selections=app.selections, cmip_names=cmip_names)"
    ]
   },
   {
@@ -914,10 +914,10 @@
    "outputs": [],
    "source": [
     "app.selections.timescale = 'monthly'\n",
-    "app.location.area_subset = 'lat/lon'\n",
-    "app.location.cached_area = 'coordinate selection'\n",
-    "app.location.latitude = (37,38.5)\n",
-    "app.location.longitude = (-123,-121.5)\n",
+    "app.selections.area_subset = 'lat/lon'\n",
+    "app.selections.cached_area = 'coordinate selection'\n",
+    "app.selections.latitude = (37,38.5)\n",
+    "app.selections.longitude = (-123,-121.5)\n",
     "app.selections.area_average = 'Yes'\n",
     "\n",
     "reg_wrf_ds = app.retrieve().squeeze()\n",
@@ -943,10 +943,10 @@
    },
    "outputs": [],
    "source": [
-    "lat0 = app.location.latitude[0]\n",
-    "lat1 = app.location.latitude[1]\n",
-    "lon0 = app.location.longitude[0]\n",
-    "lon1 = app.location.longitude[1]\n",
+    "lat0 = app.selections.latitude[0]\n",
+    "lat1 = app.selections.latitude[1]\n",
+    "lon0 = app.selections.longitude[0]\n",
+    "lon1 = app.selections.longitude[1]\n",
     "\n",
     "cads_rel_delta_percentile = (\n",
     "    (cads_delta_percentile / cads_hist_percentile\n",
@@ -1127,8 +1127,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.location.area_subset='states'\n",
-    "app.location.cached_area = 'CA'\n",
+    "app.selections.area_subset='states'\n",
+    "app.selections.cached_area = 'CA'\n",
     "app.selections.area_average = 'No'\n",
     "app.selections.timescale = 'monthly'\n",
     "\n",

--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -379,7 +379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -91,7 +91,7 @@
    "source": [
     "Nothing is required to enter these selections, besides moving on to Step 2.\n",
     "\n",
-    "However, if you want to preview what has been selected, you can type \"app.selections\" alone in a new cell, and \"app.location\". These store your selections behind-the-scenes.\n",
+    "However, if you want to preview what has been selected, you can type \"app.selections\" alone in a new cell. This stores your selections behind-the-scenes.\n",
     "\n",
     "($+$ will create a new cell, following the currently selected) \n",
     "\n",

--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -102,9 +102,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.location.data_type = \"Station\"\n",
-    "app.location.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
-    "app.location.cached_area = \"SMUD Service Territory\"\n",
+    "app.selections.data_type = \"Station\"\n",
+    "app.selections.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
+    "app.selections.cached_area = \"SMUD Service Territory\"\n",
     "app.selections.historical_scenario = \"Historical Climate\"\n",
     "app.selections.scenario_ssp = [\"SSP 3-7.0 -- Business as Usual\"]\n",
     "app.selections.time_slice = (2005,2025)\n",
@@ -231,9 +231,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.location.data_type = \"Gridded\"\n",
-    "app.location.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
-    "app.location.cached_area = \"SMUD Service Territory\"\n",
+    "app.selections.data_type = \"Gridded\"\n",
+    "app.selections.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
+    "app.selections.cached_area = \"SMUD Service Territory\"\n",
     "app.selections.historical_scenario = \"Historical Climate\"\n",
     "app.selections.scenario_ssp = [\"SSP 3-7.0 -- Business as Usual\"]\n",
     "app.selections.time_slice = (2005,2025)\n",
@@ -802,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/specific_use_cases/DFU_work_in_progress/localization.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/localization.ipynb
@@ -98,8 +98,8 @@
     "app.selections.timescale = 'hourly'\n",
     "app.selections.variable = 'Air Temperature at 2m'\n",
     "app.selections.units = 'degF'\n",
-    "app.location.area_subset = 'CA counties'\n",
-    "app.location.cached_area = 'Sacramento County'\n",
+    "app.selections.area_subset = 'CA counties'\n",
+    "app.selections.cached_area = 'Sacramento County'\n",
     "\n",
     "wrf_ds = app.retrieve()\n",
     "wrf_ds = wrf_ds.sel(simulation = 'cesm2').squeeze()"
@@ -515,7 +515,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/station_8760s.ipynb
@@ -673,7 +673,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR should be run in the climakitae branch `mapview`. That branch combines `app.selections` and `app.location`, such that it's just `app.selections` now, which contains both data and location information. I had to modify notebooks that worked directly with `app.location` to function with this new update. 

Perhaps we can tag team the review of this PR since it requires looking over so many notebooks (i.e. one person looks over 1-2 notebooks each?) 