### PR TITLE
remove refs to app.location

### DIFF
--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -102,9 +102,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "app.location.data_type = \"Station\"\n",
-    "app.location.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
-    "app.location.cached_area = \"SMUD Service Territory\"\n",
+    "app.selections.data_type = \"Station\"\n",
+    "app.selections.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
+    "app.selections.cached_area = \"SMUD Service Territory\"\n",
     "app.selections.historical_scenario = \"Historical Climate\"\n",
     "app.selections.scenario_ssp = [\"SSP 3-7.0 -- Business as Usual\"]\n",
     "app.selections.time_slice = (2005,2025)\n",


### PR DESCRIPTION
Looks like the `app.location` option no longer exists and those selection fields are all under `app.selections` now