### PR TITLE
Improve outdated markdown instructions and warming levels bug

### DIFF
--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -293,7 +293,7 @@
     "                         figsize=[15,5],cmap=cmap)\n",
     "for ax in gridded.axes.flat:\n",
     "    ax.coastlines()\n",
-    "    ax.scatter(power_plants.lon, power_plants.lat, transform=ccrs.PlateCarree(),s=0.2,c='k')"
+    "    ax.scatter(power_plants.geometry.x, power_plants.geometry.y, transform=ccrs.PlateCarree(),s=0.2,c='k')"
    ]
   },
   {
@@ -379,7 +379,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/threshold_tools_basics.ipynb
+++ b/threshold_tools_basics.ipynb
@@ -164,7 +164,7 @@
       "source": [
         "In the code cell below, the `app.select()` function of the `climakitae` app displays an interface for data selection. The selected data will be used to calculate return values, probabilities, and periods.\n",
         "\n",
-        "To perform the example analyses provided later in the notebook, use the data defaults on the `app.select()` GUI. Use the area subset option below the inset map to subset the data by the state of California (CA).\n",
+        "To perform the example analyses provided later in the notebook, use the area subset option dropdown option (displayed in `app.select()` below the inset map) to subset the data to the state of California (CA). Otherwise, you can keep the default options displayed by the panel the same.\n",
         "\n",
         "To learn more about the data available on the Analytics Engine, see our [data catalog](https://analytics.cal-adapt.org/data/). The *getting_started.ipynb* notebook contains additional explanations of the data.\n",
         "\n",

--- a/threshold_tools_basics.ipynb
+++ b/threshold_tools_basics.ipynb
@@ -164,7 +164,7 @@
       "source": [
         "In the code cell below, the `app.select()` function of the `climakitae` app displays an interface for data selection. The selected data will be used to calculate return values, probabilities, and periods.\n",
         "\n",
-        "To perform the example analyses provided later in the notebook, use the defaults in the first tab on the interface. Then, in the second tab, subset the data by the state of California (CA).\n",
+        "To perform the example analyses provided later in the notebook, use the data defaults on the `app.select()` GUI. Use the area subset option below the inset map to subset the data by the state of California (CA).\n",
         "\n",
         "To learn more about the data available on the Analytics Engine, see our [data catalog](https://analytics.cal-adapt.org/data/). The *getting_started.ipynb* notebook contains additional explanations of the data.\n",
         "\n",


### PR DESCRIPTION
The thresholds_basics notebook has instructions that reference an old setup of app.select, which had two panels. I just slightly modified the wording to fix this.

Also, this PR fixes a broken plotting situation in explore_warming. I think the URL to the powerplant shapefile had been changed (we should probably not link to external sites for this reason!) 

I meant to do these in two separate branches but my Friday brain got mixed up, which is why they are in the same PR. 