### PR TITLE
markdown switch to reflect equation improvement

### DIFF
--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -653,7 +653,7 @@
     "## Step 5: Compute heating degree hours and cooling degree hours\n",
     "Alternatively, you may be interested in the number of hours in each day that a designated heating or cooling threshold crosses. For Cooling Degree Hours (CDH), this is the number of hours in which the hourly temperature exceeds the cooling degree threshold. Likewise, Heating Degree Hours (HDH) is the number of hours in which the hourly temperature is below the heating degree threshold. We'll use the helper function `compute_hdh_cdh` to calculate HDH and CDH:<br><br>\n",
     "**CDH = num of hours where (temperature $>$ threshold)<br>\n",
-    "HDH = num of hours where (-1)\\*(temperature $<$ threshold)**<br><br>\n",
+    "HDH = num of hours where (temperature $<$ threshold)**<br><br>\n",
     "We will display the results to see how trends change throughout the year. "
    ]
   },
@@ -742,7 +742,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0658136c-a412-4ef6-99fa-1eac0f586997",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "data_one_year = cdh_aggregated.sel(time=\"2021\")\n",
@@ -802,7 +804,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Literally removed 4 characters from a line of markdown to reflect that the (-1) isn't applied to the CDH/HDH calculation. Code updated in https://github.com/cal-adapt/climakitae/pull/236