### PR TITLE
Fix for the INTRO notebook for calculating HDD/CDD with station data

### DIFF
--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -454,14 +454,14 @@
    },
    "outputs": [],
    "source": [
-    "# # ALL DATA WITHIN DFZ ZONE\n",
-    "# data_to_use = data_dfz.resample(time='1D').mean() # Resamples to daily data\n",
-    "# num_grid_cells = data_dfz.x.size * data_dfz.y.size # Number of grid cells within the demand forecast region\n",
+    "# ALL DATA WITHIN DFZ ZONE\n",
+    "data_to_use = data_dfz.resample(time='1D').mean() # Resamples to daily data\n",
+    "num_grid_cells = data_dfz.x.size * data_dfz.y.size # Number of grid cells within the demand forecast region\n",
     "\n",
-    "# # CLOSEST GRID CELL \n",
-    "data_to_use = data_at_station.to_array(name='Air Temperature at 2m').squeeze()\n",
-    "data_to_use = data_to_use.resample(time='1D').mean() # Resamples to daily data\n",
-    "num_grid_cells = 1"
+    "# # # CLOSEST GRID CELL \n",
+    "# data_to_use = data_at_station.to_array(name='Air Temperature at 2m').squeeze()\n",
+    "# data_to_use = data_to_use.resample(time='1D').mean() # Resamples to daily data\n",
+    "# num_grid_cells = 1"
    ]
   },
   {
@@ -722,6 +722,7 @@
    },
    "outputs": [],
    "source": [
+    "data_to_use = data_dfz # reset to hourly data\n",
     "hdh, cdh = compute_hdh_cdh(data_to_use, hdh_threshold=60, cdh_threshold=70) # Set for all data within selected DFZ zone"
    ]
   },

--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -51,10 +51,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "10b1980c-c7f7-48f0-91cd-388e6aa46793",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "from climakitae.utils import compute_annual_aggreggate, trendline, compute_multimodel_stats, hdd_cdd_lineplot, hdh_cdh_lineplot\n",
+    "from climakitae.utils import compute_annual_aggreggate, trendline, compute_multimodel_stats, hdd_cdd_lineplot, hdh_cdh_lineplot, combine_hdd_cdd\n",
     "from climakitae.derive_variables import compute_hdd_cdd, compute_hdh_cdh\n",
     "import climakitae as ck"
    ]
@@ -329,10 +331,12 @@
    },
    "outputs": [],
    "source": [
-    "app.view(to_plot) * point_df.hvplot.points(\n",
-    "    hover_cols = [\"weather station\"], \n",
-    "    marker = \"star\", size = 300, color = \"black\"\n",
-    ")"
+    "# app.view(to_plot) * point_df.hvplot.points(\n",
+    "#     hover_cols = [\"weather station\"], \n",
+    "#     marker = \"star\", size = 300, color = \"black\"\n",
+    "# )\n",
+    "\n",
+    "app.view(to_plot)"
    ]
   },
   {
@@ -407,7 +411,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ee1ab9af-4c01-4814-8513-2bd0e8ab9bb1",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "filename = \"dfz_aggregated_{0}.csv\".format(station_name.replace(\" \", \"_\").lower())\n",
@@ -715,7 +721,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51af09c3-cfd6-404a-8cbc-71c49deb59a8",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdh, cdh = compute_hdh_cdh(data_to_use, hdh_threshold=60, cdh_threshold=70) # Set for all data within selected DFZ zone"
@@ -725,11 +733,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e6b64873-50d7-4134-973b-de80f237198d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "hdh_aggregated = hdh.median(dim=[\"x\",\"y\"])\n",
-    "cdh_aggregated = cdh.median(dim=[\"x\",\"y\"])"
+    "# only for all data within DFZ zone, not station data\n",
+    "hdh = hdh.median(dim=[\"x\",\"y\"])\n",
+    "cdh = cdh.median(dim=[\"x\",\"y\"])"
    ]
   },
   {
@@ -747,10 +758,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "124475ad-df98-4404-ba90-fa54be2880b6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "data_one_month = cdh_aggregated.sel(time=\"June 2011\")\n",
+    "data_one_month = cdh.sel(time=\"June 2011\")\n",
     "hdh_cdh_lineplot(data_one_month)"
    ]
   },
@@ -758,10 +771,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "207ab41e-7eea-42b7-b7bf-4b690157d52e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "data_one_month = hdh_aggregated.sel(time=\"June 2011\")\n",
+    "data_one_month = hdh.sel(time=\"June 2011\")\n",
     "hdh_cdh_lineplot(data_one_month)"
    ]
   },
@@ -782,8 +797,18 @@
    },
    "outputs": [],
    "source": [
-    "data_one_year = cdh_aggregated.sel(time=\"2021\")\n",
+    "data_one_year = cdh.sel(time=\"2021\")\n",
     "hdh_cdh_lineplot(data_one_year)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82448725-a99b-493a-907d-4bbb9ccc791e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdh"
    ]
   },
   {
@@ -799,11 +824,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "93f1b639-6caf-48a3-b477-6beac0ee9fd6",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Merge and simplify data \n",
-    "hdh_cdh_combined = xr.merge([hdh_aggregated, cdh_aggregated]).drop([\"Lambert_Conformal\",\"scenario\"])\n",
+    "hdh_cdh_combined = xr.merge([combine_hdd_cdd(hdh), combine_hdd_cdd(cdh)])\n",
     "hdh_cdh_combined = app.load(hdh_cdh_combined) \n",
     "\n",
     "# Convert to pandas dataframe \n",
@@ -821,6 +848,14 @@
     "filename = \"daily_hdh_cdh_{0}.csv\".format(station_name.replace(\" \", \"_\").lower())\n",
     "hdh_cdh_df.to_csv(filename, index=True)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae77e28d-2df4-43b0-8054-61b7b2452ea3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -101,7 +101,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d762303-4038-4394-af1f-937a4cba5ad0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "app.selections.data_type = \"Station\"\n",
@@ -121,7 +123,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a85d4be9-1fab-4d38-a850-972a2e4259dd",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "data_at_station = app.retrieve()\n",
@@ -141,7 +145,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "82c96c9d-14cd-425e-8d9d-ad1b178e05c3",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -449,11 +455,12 @@
    "outputs": [],
    "source": [
     "# ALL DATA WITHIN DFZ ZONE\n",
-    "data_to_use = data_dfz\n",
+    "data_to_use = data_dfz.resample(time='1D').mean() # Resamples to daily data\n",
     "num_grid_cells = data_dfz.x.size * data_dfz.y.size # Number of grid cells within the demand forecast region\n",
     "\n",
-    "# # CLOSEST GRID CELL \n",
-    "# data_to_use = data_at_station.to_array(name='Air Temperature at 2m')\n",
+    "# # # CLOSEST GRID CELL \n",
+    "# data_to_use = data_at_station.to_array(name='Air Temperature at 2m').squeeze()\n",
+    "# data_to_use = data_to_use.resample(time='1D').mean() # Resamples to daily data\n",
     "# num_grid_cells = 1"
    ]
   },
@@ -490,7 +497,7 @@
    },
    "outputs": [],
    "source": [
-    "hdd, cdd = compute_hdd_cdd(data_to_use, hdd_threshold=60, cdd_threshold=70) # Set for all data within selected DFZ zone"
+    "hdd, cdd = compute_hdd_cdd(data_to_use, hdd_threshold=65, cdd_threshold=65) # Set for all data within selected DFZ zone"
    ]
   },
   {
@@ -545,18 +552,6 @@
     "    name=\"Annual Cooling Degree Days (CDD)\", \n",
     "    num_grid_cells=num_grid_cells\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f9a4c365-fe76-4659-8789-cf54856f997a",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "cdd_annual"
    ]
   },
   {

--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -442,7 +442,7 @@
    "source": [
     "### 4a) Decide which input data you want to use \n",
     "\n",
-    "You can use the data within the demand forecast zone, which we retrieved in **step 2b**. Or, you can use the closest grid cell to the weather station, which we computed in **step 1b**. We do not recommend using the aggregated DFZ data calculated in step 3b, as aggregating the data prior to computing HDD and CDD may remove some critical information about the weather extremes. You can comment out whichever method you don't want to use. We've chosen to show the analysis with the DFZ data, but if you want to use the closest grid cell data, just comment out the DFZ cells and uncomment the closest grid cells.<br><br>Depending on the input data, we will also set a new variable defining the number of grid cells. This will of course be just 1 for the closest grid cell method; for the DFZ data, however, this value will change depending on the size of the DFZ. This information is used to compute the annual aggregate HDD and CDD in step 4c."
+    "You can use the data within the demand forecast zone, which we retrieved in **step 2b**. Or, you can use the closest grid cell to the weather station, which we computed in **step 1b**. We do not recommend using the aggregated DFZ data calculated in step 3b, as aggregating the data prior to computing HDD and CDD may remove some critical information about the weather extremes. You can comment out whichever method you don't want to use. We've chosen to show the analysis with the DFZ data, but if you want to use the closest grid cell data, just comment out the DFZ cells and uncomment the closest grid cells. Note, the closest grid cell resampling will take a few minutes! <br><br>Depending on the input data, we will also set a new variable defining the number of grid cells. This will of course be just 1 for the closest grid cell method; for the DFZ data, however, this value will change depending on the size of the DFZ before aggregating. This information is used to compute the annual aggregate HDD and CDD in step 4c."
    ]
   },
   {
@@ -454,14 +454,14 @@
    },
    "outputs": [],
    "source": [
-    "# ALL DATA WITHIN DFZ ZONE\n",
-    "data_to_use = data_dfz.resample(time='1D').mean() # Resamples to daily data\n",
-    "num_grid_cells = data_dfz.x.size * data_dfz.y.size # Number of grid cells within the demand forecast region\n",
+    "# # ALL DATA WITHIN DFZ ZONE\n",
+    "# data_to_use = data_dfz.resample(time='1D').mean() # Resamples to daily data\n",
+    "# num_grid_cells = data_dfz.x.size * data_dfz.y.size # Number of grid cells within the demand forecast region\n",
     "\n",
-    "# # # CLOSEST GRID CELL \n",
-    "# data_to_use = data_at_station.to_array(name='Air Temperature at 2m').squeeze()\n",
-    "# data_to_use = data_to_use.resample(time='1D').mean() # Resamples to daily data\n",
-    "# num_grid_cells = 1"
+    "# # CLOSEST GRID CELL \n",
+    "data_to_use = data_at_station.to_array(name='Air Temperature at 2m').squeeze()\n",
+    "data_to_use = data_to_use.resample(time='1D').mean() # Resamples to daily data\n",
+    "num_grid_cells = 1"
    ]
   },
   {
@@ -505,7 +505,7 @@
    "id": "f9250344-7103-40e3-8c03-7da17d080cc7",
    "metadata": {},
    "source": [
-    "Now that we have computed the HDD and CDD, we can then aggregate the results across grid cells in the forecast zone like we did previously above. We will need to do this for both the HDD and CDD variables. If you would like to change the aggregation method, you can easily modify between **median, mean, min, or max**, or write your own code to compute a weighted mean here too. We will use the *median* as an example here. \n",
+    "Now that we have computed the HDD and CDD, we can then aggregate the results across grid cells in the forecast zone like we did previously above. We will need to do this for both the HDD and CDD variables. If you would like to change the aggregation method, you can easily modify between **median, mean, min, or max**, or write your own code to compute a weighted mean here too. We will use the *median* as an example here. Note, because we are aggregating here, the number of grid cells is reduced to represent the aggregation method to 1. \n",
     "\n",
     "Please note, that this next step is **not required** if you selected the closest grid cell to the station instead of all data across the DFZ. "
    ]
@@ -521,7 +521,8 @@
    "source": [
     "# only for all data within DFZ zone, not station data\n",
     "hdd = hdd.median(dim=[\"x\",\"y\"])\n",
-    "cdd = cdd.median(dim=[\"x\",\"y\"])"
+    "cdd = cdd.median(dim=[\"x\",\"y\"])\n",
+    "num_grid_cells = 1"
    ]
   },
   {

--- a/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
+++ b/specific_use_cases/DFU_work_in_progress/INTRO_annual_consumption_model.ipynb
@@ -324,7 +324,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7f142cf6-c160-495b-b701-9c3e17b45302",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "app.view(to_plot) * point_df.hvplot.points(\n",
@@ -346,7 +348,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ea9aa428-48d4-4944-b653-39a142041d70",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "data_dfz_aggregated = data_dfz.median(dim=[\"x\",\"y\"])\n",
@@ -367,7 +371,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a3c2715d-658b-431f-880e-453203450556",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -387,7 +393,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d0e5c476-9a73-4da4-8b20-c95e400eaede",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "dfz_aggregated_df = data_dfz_aggregated.isel(scenario=0).drop(\n",
@@ -429,15 +437,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "64b4413e-e085-409c-a603-7232a3bd5781",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# ALL DATA WITHIN DFZ ZONE\n",
     "data_to_use = data_dfz\n",
     "num_grid_cells = data_dfz.x.size * data_dfz.y.size # Number of grid cells within the demand forecast region\n",
     "\n",
-    "# CLOSEST GRID CELL \n",
-    "# data_to_use = data_at_station\n",
+    "# # CLOSEST GRID CELL \n",
+    "# data_to_use = data_at_station.to_array(name='Air Temperature at 2m')\n",
     "# num_grid_cells = 1"
    ]
   },
@@ -457,7 +467,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e43ab84e-93c5-4d88-8585-9a2e25a12d31",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "#help(compute_hdd_cdd) # See information about the function"
@@ -467,7 +479,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fcf8afd0-3889-4fb2-8e0c-4fc4ba85975b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdd, cdd = compute_hdd_cdd(data_to_use, hdd_threshold=60, cdd_threshold=70) # Set for all data within selected DFZ zone"
@@ -478,18 +492,23 @@
    "id": "f9250344-7103-40e3-8c03-7da17d080cc7",
    "metadata": {},
    "source": [
-    "Now that we have computed the HDD and CDD, we can then aggregate the results across grid cells in the forecast zone like we did previously above. We will need to do this for both the HDD and CDD variables. If you would like to change the aggregation method, you can easily modify between **median, mean, min, or max**, or write your own code to compute a weighted mean here too. We will use the *median* as an example here. "
+    "Now that we have computed the HDD and CDD, we can then aggregate the results across grid cells in the forecast zone like we did previously above. We will need to do this for both the HDD and CDD variables. If you would like to change the aggregation method, you can easily modify between **median, mean, min, or max**, or write your own code to compute a weighted mean here too. We will use the *median* as an example here. \n",
+    "\n",
+    "Please note, that this next step is **not required** if you selected the closest grid cell to the station instead of all data across the DFZ. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1a798614-e387-4a96-a7a4-de11bdefd668",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "hdd_aggregated = hdd.median(dim=[\"x\",\"y\"])\n",
-    "cdd_aggregated = cdd.median(dim=[\"x\",\"y\"])"
+    "# only for all data within DFZ zone, not station data\n",
+    "hdd = hdd.median(dim=[\"x\",\"y\"])\n",
+    "cdd = cdd.median(dim=[\"x\",\"y\"])"
    ]
   },
   {
@@ -505,16 +524,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1d1af18-bb1f-43d7-9143-97c13d0eb383",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdd_annual = compute_annual_aggreggate(\n",
-    "    data=hdd_aggregated, \n",
+    "    data=hdd, \n",
     "    name=\"Annual Heating Degree Days (HDD)\", \n",
     "    num_grid_cells=num_grid_cells\n",
     ")\n",
     "cdd_annual = compute_annual_aggreggate(\n",
-    "    data=cdd_aggregated, \n",
+    "    data=cdd, \n",
     "    name=\"Annual Cooling Degree Days (CDD)\", \n",
     "    num_grid_cells=num_grid_cells\n",
     ")"
@@ -524,7 +545,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f9a4c365-fe76-4659-8789-cf54856f997a",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "cdd_annual"
@@ -543,7 +566,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e136ea87-b766-4b47-9783-db9668d618e0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdd_annual = compute_multimodel_stats(hdd_annual)\n",
@@ -563,7 +588,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "90e81e5d-1277-4218-8e95-7e138c1793fa",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdd_trendline = trendline(hdd_annual) \n",
@@ -585,7 +612,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b5e094aa-b9b7-4cd1-9f1a-8f2ac7adea4d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdd_cdd_lineplot(\n",
@@ -599,7 +628,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "95dab899-3053-4e62-8d54-59ec867ab30c",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hdd_cdd_lineplot(\n",
@@ -622,12 +653,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cf13ea2a-fb98-4438-ba98-fb7b1039d579",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Merge and simplify data \n",
-    "hdd_cdd_combined = xr.merge([hdd_annual, cdd_annual]).drop([\"Lambert_Conformal\",\"scenario\"])\n",
-    "hdd_cdd_combined = app.load(hdd_cdd_combined) \n",
+    "hdd_cdd_combined = xr.merge([combine_hdd_cdd(hdd_annual), combine_hdd_cdd(cdd_annual)])\n",
+    "hdd_cdd_combined = app.load(hdd_cdd_combined)\n",
     "\n",
     "# Convert to pandas dataframe \n",
     "hdd_cdd_df = hdd_cdd_combined.to_dataframe()\n",
@@ -638,7 +671,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c1e3937b-1e36-4164-b96a-55b097d56c49",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "filename = \"annual_hdd_cdd_{0}.csv\".format(station_name.replace(\" \", \"_\").lower())\n",


### PR DESCRIPTION
The INTRO_annual_consumption model previously provided the option to calculate HDDs/CDDs using either an aggregation over the DFU zone, or to use the closest gridcell to the weather station itself, however much of the notebook was configured for the gridded data and would break if station gridcell option was selected instead. 

**Note 1**: Our previous calculation for CDD/HDD was incorrect as it did not resample the hourly to daily data to calculate CDD/HDD accurately for either gridded or station data, this would produce reasonable but low values in the gridded data, and several orders of magnitude too large in the station data. This is now fixed by resampling. 

**Note 2**: The plot of the gridded station data with the overlay station scatterpoint **does not work** - I believe this is because app.view now returns a panel object instead. This needs to be fixed.

---
To test:
Run the INTRO notebook for both options in Step 4 (i.e., test once with the default behavior in Step 4a, and then the "closest grid cell" option) and make sure data is produced. This notebook also needs to be run in the `fix_dd` climakitae branch - also in PR here: https://github.com/cal-adapt/climakitae/pull/273