### PR TITLE
Update export guidance

### DIFF
--- a/explore_amy.ipynb
+++ b/explore_amy.ipynb
@@ -282,11 +282,12 @@
    "id": "ef6b147c-ad5f-41ea-89f0-4ff5aca9a9f7",
    "metadata": {},
    "source": [
-    "To export the data that is used to calculate the Average Meteorological Year (not the AMY result), first pick a format from the dropdown menu.\n",
+    "To export other data, call `export` and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. amy.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\" or \"CSV\")\n",
     "\n",
-    "- We recommend NetCDF, which will work with any number of variables and dimensions in your dataset\n",
-    "- CSV works best up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF is not possible for Average Meteorological Year as the time series data does not retain a spatial component"
+    "To learn more about the file format options, see [getting_started.ipynb](getting_started.ipynb)."
    ]
   },
   {
@@ -294,26 +295,20 @@
    "id": "9d6ba840-a1d2-49e9-aa3b-0eaf76034b16",
    "metadata": {},
    "source": [
-    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+    "As an example, the following code exports the data that is used to calculate the Average Meteorological Year (not the AMY result) to a NetCDF file named \"my_filename\"."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "9e20abd3-bde3-4896-b10a-52063ceac085",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "ck.export(my_data, 'my_filename', \"NetCDF\")"
+    "ck.export(my_data, \"my_filename\", \"NetCDF\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e74c2048-b477-428a-b346-08b25bb05a6f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -262,7 +262,7 @@
    "source": [
     "## Step 3: Export\n",
     "\n",
-    "To save data as a file, call 'export' and input your desired\n",
+    "To save data as a file, call `export` and input your desired\n",
     "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. wl.retrieve()\n",
     "2) output file name (without file extension)\n",
     "3) file format (\"NetCDF\" or \"CSV\")\n",

--- a/explore_warming.ipynb
+++ b/explore_warming.ipynb
@@ -262,22 +262,12 @@
    "source": [
     "## Step 3: Export\n",
     "\n",
-    "To export, first pick a format from the dropdown menu.\n",
-    "- We recommend NetCDF, which will work with any number of variables and dimensions in your dataset\n",
-    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
-    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions total: \n",
-    "    - X and Y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "be14a5bf-b766-4a43-9ed5-16c0737c980c",
-   "metadata": {},
-   "source": [
-    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+    "To save data as a file, call 'export' and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. wl.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\" or \"CSV\")\n",
+    "\n",
+    "To learn more about the file format options, see [getting_started.ipynb](getting_started.ipynb)."
    ]
   },
   {
@@ -287,16 +277,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ck.export(plots, 'my_filename', \"NetCDF\")"
+    "ck.export(plots, \"my_filename\", \"NetCDF\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a2a2cbed-be92-4dd2-a816-adf8dae243c7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -212,7 +212,7 @@
    "source": [
     "## Step 4: Export data\n",
     "\n",
-    "To save data as a file, call 'export' and input your desired\n",
+    "To save data as a file, call `export` and input your desired\n",
     "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
     "2) output file name (without file extension)\n",
     "3) file format (\"NetCDF\" or \"CSV\")\n",

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -78,7 +78,7 @@
     "($+$ will create a new cell, following the currently selected) \n",
     "\n",
     "## Step 2: Retrieve data\n",
-    "Call selections.retrieve(), to assign the subset/combo of data specified to a variable name of your choosing, in an xarray [DataArray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html) format."
+    "Call selections.retrieve(), to assign the subset/combo of data specified to a variable name of your choosing, in [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html) format."
    ]
   },
   {
@@ -207,33 +207,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f76b5ca9",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
    "id": "b9688a2a-e72b-4239-b8fb-56ae8080bdc5",
    "metadata": {},
    "source": [
     "## Step 4: Export data\n",
     "\n",
-    "To export, first pick a format from the dropdown menu.\n",
-    "- We recommend NetCDF, which will work with any number of variables and dimensions in your dataset\n",
-    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
-    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions total: \n",
-    "    - X and Y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "35321f78-0a2b-465a-9ebb-f5441c95ab53",
-   "metadata": {},
-   "source": [
-    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+    "To save data as a file, call 'export' and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\" or \"CSV\")\n",
+    "\n",
+    "We recommend NetCDF, which suits data and outputs from the Analytics Engine well – it efficiently stores large data containing multiple variables and dimensions. Metadata will be retained in NetCDF files.\n",
+    "\n",
+    "CSV can also store Analytics Engine data with any number of variables and dimensions. It works the best for smaller data with fewer dimensions. The output file will be compressed to ensure efficient storage. Metadata will be preserved in a separate file.\n",
+    "\n",
+    "CSV stores data in tabular format. Rows will be indexed by the index coordinate(s) of the DataArray or Dataset (e.g. scenario, simulation, time). Columns will be formed by the data variable(s) and non-index coordinate(s)."
    ]
   },
   {
@@ -243,16 +231,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ck.export(data_to_use, 'my_filename', \"NetCDF\")"
+    "ck.export(data_to_use, \"my_filename\", \"NetCDF\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0e2aaf3e-51e4-4812-acc5-f19e17a23b2a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/timeseries_example.ipynb
+++ b/timeseries_example.ipynb
@@ -190,18 +190,12 @@
    "source": [
     "## Step 5: Export\n",
     "\n",
-    "To export, first pick a format from the dropdown menu.\n",
-    "- We recommend NetCDF, which will work with any number of variables and dimensions in your dataset\n",
-    "- CSV works best up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF is not possible as the time series data does not retain a spatial component"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cd729c6a-62e4-4388-b570-7b6ce76a3712",
-   "metadata": {},
-   "source": [
-    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+    "To save data as a file, call `export` and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\" or \"CSV\")\n",
+    "\n",
+    "To learn more about the file format options, see [getting_started.ipynb](getting_started.ipynb)."
    ]
   },
   {
@@ -211,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ck.export(transformed, 'my_filename', \"NetCDF\")"
+    "ck.export(transformed, \"my_filename\", \"NetCDF\")"
    ]
   }
  ],

--- a/work_in_progress/threshold_tools_application_examples.ipynb
+++ b/work_in_progress/threshold_tools_application_examples.ipynb
@@ -620,16 +620,12 @@
    "id": "6e2d8b88-ad5f-419e-b015-c473434fe9cc",
    "metadata": {},
    "source": [
-    "To export the threshold tools variables, we recommend NetCDF file format, which will work with any number of variables and dimensions in your dataset. \n",
-    "If you would like to save data as a GeoTIFF or CSV file and the dataset contains scenarios or simulations, additionally provide arguments specifying the scenario (scenario=”historical”) and the simulation (simulation=”cesm2”).\n",
-    "- CSV and GeoTIFF can only be used for data arrays with one variable\n",
-    "- CSV works best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions total:\n",
-    "    - X and Y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif\n",
+    "To save data as a file, call `export` and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\" or \"CSV\")\n",
     "\n",
-    "To export as a GeoTIFF or CSV file, please subset the data with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work)."
+    "To learn more about the file format options, see [getting_started.ipynb](getting_started.ipynb)."
    ]
   },
   {
@@ -637,7 +633,7 @@
    "id": "7d0a91c7-9807-45b0-bb5e-698c812d139a",
    "metadata": {},
    "source": [
-    "Next, write in the object you wish to export and your desired filename (in single or double quotation marks)."
+    "As an example, the following code exports `sacramento_2050_rp` to a NetCDF file named \"my_filename_1\"."
    ]
   },
   {
@@ -647,7 +643,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ck.export(sacramento_2050_rp, 'my_filename_1', \"NetCDF\")"
+    "ck.export(sacramento_2050_rp, \"my_filename_1\", \"NetCDF\")"
    ]
   },
   {
@@ -655,7 +651,7 @@
    "id": "d3006556-0451-4b43-b91c-700ff195f765",
    "metadata": {},
    "source": [
-    "An example of subsetting is below, for exporting to a CSV or GeoTIFF."
+    "You may also export only one of the variables in an xarray Dataset. For example:"
    ]
   },
   {
@@ -665,7 +661,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sacramento_1980_rp_variable = sacramento_1980_rp['return_period']"
+    "variable = \"return_period\"\n",
+    "sacramento_1980_rp_variable = sacramento_1980_rp[variable]"
    ]
   },
   {
@@ -675,7 +672,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ck.export(sacramento_1980_rp_variable, 'my_filename_2', \"CSV\")"
+    "ck.export(sacramento_1980_rp_variable, \"my_filename_2\", \"CSV\")"
    ]
   }
  ],

--- a/work_in_progress/threshold_tools_basics.ipynb
+++ b/work_in_progress/threshold_tools_basics.ipynb
@@ -713,25 +713,27 @@
    "cell_type": "markdown",
    "id": "b9688a2a-e72b-4239-b8fb-56ae8080bdc5",
    "metadata": {
-    "id": "b9688a2a-e72b-4239-b8fb-56ae8080bdc5"
+    "id": "b9688a2a-e72b-4239-b8fb-56ae8080bdc5",
+    "tags": []
    },
    "source": [
     "<a id='export'></a>\n",
     "## Step 5: Export results\n",
     "\n",
-    "To export any `DataArray` or `Dataset` object in the notebook (the AMS, the return values, etc.), first execute the following code cell and pick a file format.\n",
+    "To save data as a file, call `export` and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\" or \"CSV\")\n",
     "\n",
-    "__Tip:__ We recommend the NetCDF file format, which will work with any number of dimensions in your `DataArray` or `Dataset`."
+    "To learn more about the file format options, see [getting_started.ipynb](getting_started.ipynb)."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4cb3a817-9313-49d0-9fac-ae4810f63110",
-   "metadata": {
-    "id": "4cb3a817-9313-49d0-9fac-ae4810f63110"
-   },
+   "id": "0695b751-2248-444e-8f14-d8757393ab75",
+   "metadata": {},
    "source": [
-    "Next, specify the `DataArray` or `Dataset` object you wish to export and your desired file name (in single or double quotation marks)."
+    "As an example, the following code exports `return_period` to a NetCDF file named \"my_filename_1\"."
    ]
   },
   {
@@ -743,7 +745,7 @@
    },
    "outputs": [],
    "source": [
-    "ck.export(return_period, 'my_filename_1', \"NetCDF\")"
+    "ck.export(return_period, \"my_filename_1\", \"NetCDF\")"
    ]
   },
   {
@@ -753,25 +755,7 @@
     "id": "087c0d3d-e96d-4134-b37f-7c90db035154"
    },
    "source": [
-    "If you would like to save data as a CSV or GeoTIFF file, __please note:__\n",
-    "\n",
-    "- CSV and GeoTIFF can only be used for `DataArray`\n",
-    "- CSV works the best for up to 2-dimensional data (e.g., lon x lat), and will be compressed and exported with a separate metadata file\n",
-    "- GeoTIFF can accept 3 dimensions in total:\n",
-    "    - x and y dimensions are required\n",
-    "    - The third dimension is flexible and will be a \"band\" in the file: time, simulation, or scenario could go here\n",
-    "    - Metadata will be accessible as \"tags\" in the .tif file\n",
-    "    \n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "XuuVcrS1012j",
-   "metadata": {
-    "id": "XuuVcrS1012j"
-   },
-   "source": [
-    "To export a `Dataset` as a CSV or GeoTIFF file, please subset it with your desired variable first, then select either CSV or GeoTIFF as your format (NetCDF will also work). For example:"
+    "You may also export only one of the variables in an xarray Dataset. For example:"
    ]
   },
   {
@@ -783,7 +767,7 @@
    },
    "outputs": [],
    "source": [
-    "variable = 'return_period'\n",
+    "variable = \"return_period\"\n",
     "return_period_variable = return_period[variable]"
    ]
   },
@@ -796,7 +780,7 @@
    },
    "outputs": [],
    "source": [
-    "ck.export(return_period_variable, 'my_filename_2', \"CSV\")"
+    "ck.export(return_period_variable, \"my_filename_2\", \"CSV\")"
    ]
   }
  ],


### PR DESCRIPTION
This PR updates notebook markdown instructions for how to use the export code revamped in [this climakitae PR](https://github.com/cal-adapt/climakitae/pull/257).

Major changes to the export feature include
- syntax simplified: `ck.export(data, 'filename', 'filetype')`
- GeoTIFF (to be) deprecated so only NetCDF and CSV left
- CSV-to-Dataset export function added so both NetCDF and CSV work for xarray DataArray and Dataset

The changes are reflected in markdown of all notebooks with an export step. Some guidance on file formats are added in `getting_started.ipynb`. Those guidance are referenced instead of spelled out in the other notebooks per Naomi's suggestion.




