### PR TITLE
Adds timezone correction to Heat Index and HDD/CDD notebooks

### DIFF
--- a/collaborative/DFU/annual_consumption_model.ipynb
+++ b/collaborative/DFU/annual_consumption_model.ipynb
@@ -60,7 +60,8 @@
    },
    "outputs": [],
    "source": [
-    "from climakitae.util.utils import compute_annual_aggreggate, trendline, compute_multimodel_stats, hdd_cdd_lineplot, hdh_cdh_lineplot, combine_hdd_cdd\n",
+    "from climakitae.util.utils import (convert_to_local_time, compute_annual_aggreggate, trendline, \n",
+    "                                   compute_multimodel_stats, hdd_cdd_lineplot, hdh_cdh_lineplot, combine_hdd_cdd)\n",
     "from climakitae.tools.derived_variables import compute_hdd_cdd, compute_hdh_cdh\n",
     "import climakitae as ck"
    ]
@@ -96,16 +97,15 @@
     "\n",
     "selections.data_type = \"Station\"\n",
     "selections.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
-    "selections.cached_area = [\"Big Creek West\"]\n",
+    "selections.cached_area = [\"SMUD Service Territory\"]\n",
     "selections.historical_scenario = \"Historical Climate\"\n",
     "selections.scenario_ssp = [\"SSP 3-7.0 -- Business as Usual\"]\n",
     "selections.time_slice = (2005,2025)\n",
     "selections.timescale = \"hourly\"\n",
     "selections.resolution = \"3 km\"\n",
     "selections.units = \"degF\"\n",
-    "# selections.station = \"Santa Barbara Municipal Airport (KSBA)\"\n",
     "\n",
-    "selections.show()"
+    "# selections.show()"
    ]
   },
   {
@@ -119,6 +119,24 @@
    "source": [
     "data_at_station = selections.retrieve()\n",
     "data_at_station"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8c93201-5a51-44c4-aaa4-ed422adb1f7e",
+   "metadata": {},
+   "source": [
+    "Becasuse the dynamically downscaled WRF data in the Cal-Adapt: Analytics Engine is in UTC time, we'll convert to the timezome of the station we've selected. This is particularly important for determining the timing of the daily maximum and minimum temperatures. For a station located in Pacific Time (US), UTC time places the daily minimum \"in\" the day prior because UTC is 8 hours ahead of Pacific! The handy `convert_to_local_time` function corrects for this, and ensures that the resulting high and low temperatures are within the same daily timestamp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ceda482-9303-4f98-ade3-65f164e40560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_at_station = convert_to_local_time(data_at_station, selections)"
    ]
   },
   {
@@ -174,7 +192,7 @@
    },
    "outputs": [],
    "source": [
-    "station_name = \"SANTA BARBARA MUNICIPAL AIRPORT\"\n",
+    "station_name = \"SACRAMENTO METROPOLITAN AP\"\n",
     "one_station = stations_df.loc[station_name]"
    ]
   },
@@ -230,7 +248,7 @@
     "\n",
     "### 2a) Select the data\n",
     "\n",
-    "Using `Select()` we have pre-loaded data selections for gridded air temperature within the Sacramento Municipal Utility District for 2005-2025. However, if you would like to make modifications, or see how the data can be selected, run `ck.Select().show` in a cell below to pull up a useful panel that illustrates all of the data options. \n",
+    "Using `Select()` we have pre-loaded data selections for gridded air temperature within the Sacramento Municipal Utility District for 2005-2025. However, if you would like to make modifications, or see how the data can be selected, run `selections.show()` in a cell below to pull up a useful panel that illustrates all of the data options. \n",
     "\n",
     "Reminder: The gridded data we will be retrieving in this step and using throughout this notebook is not bias-corrected."
    ]
@@ -246,7 +264,7 @@
    "source": [
     "selections.data_type = \"Gridded\"\n",
     "selections.area_subset = \"CA Electricity Demand Forecast Zones\"\n",
-    "selections.cached_area = [\"Big Creek West\"]\n",
+    "selections.cached_area = [\"SMUD Service Territory\"]\n",
     "selections.historical_scenario = \"Historical Climate\"\n",
     "selections.scenario_ssp = [\"SSP 3-7.0 -- Business as Usual\"]\n",
     "selections.time_slice = (2005,2025)\n",
@@ -265,6 +283,16 @@
    "outputs": [],
    "source": [
     "data_dfz = selections.retrieve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b681a024-b44f-4e25-a579-ab7a8826ab81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dfz = convert_to_local_time(data_dfz, selections)"
    ]
   },
   {
@@ -820,16 +848,6 @@
    "source": [
     "data_one_year = cdh.sel(time=\"2021\")\n",
     "hdh_cdh_lineplot(data_one_year)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "82448725-a99b-493a-907d-4bbb9ccc791e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hdh"
    ]
   },
   {

--- a/collaborative/IOU/heat_index.ipynb
+++ b/collaborative/IOU/heat_index.ipynb
@@ -37,8 +37,10 @@
    "source": [
     "import climakitae as ck\n",
     "import pandas as pd\n",
+    "from climakitae.util.utils import read_csv_file, get_closest_gridcell, compute_multimodel_stats, trendline, summary_table, convert_to_local_time\n",
     "\n",
-    "from climakitae.util.utils import read_csv_file, get_closest_gridcell, compute_multimodel_stats, trendline, summary_table"
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {
@@ -49,7 +51,7 @@
     "## Step 1: Select data\n",
     "\n",
     "### 1a) Grab location of interest by latitude and longitude\n",
-    "First we'll grab specific locations of interest, by using the latitude and longitude locations of a weather station, and provide code to input a custom lat-lon location. Furthermore, we will **not** be retrieving the actual station data that is bias-corrected to that station for this example. At present bias-corrected station data on the Analytics Engine only provides air temperature as a variable, and for Heat Index we must also have either dew point temperature (coming soon!) or relative humidity. So for the time being, we will retrieve **non-bias corrected** data at the location of interest."
+    "First we'll grab specific locations of interest, by using the latitude and longitudeconvert_to_local_timeions of a weather station, and provide code to input a custom lat-lon location. Furthermore, we will **not** be retrieving the actual station data that is bias-corrected to that station for this example. At present bias-corrected station data on the Analytics Engine only provides air temperature as a variable, and for Heat Index we must also have either dew point temperature (coming soon!) or relative humidity. So for the time being, we will retrieve **non-bias corrected** data at the location of interest."
    ]
   },
   {
@@ -138,7 +140,7 @@
    "id": "d8b0e172-6423-4551-b207-f445ba24e16b",
    "metadata": {},
    "source": [
-    "Next, we'll use the latitude and longitude values to retrieve the historical data at that gridcell. "
+    "Becasuse the dynamically downscaled WRF data in the Cal-Adapt: Analytics Engine is in UTC time, we'll convert to the timezome of the station we've selected. This is particularly important for determining the timing of the daily maximum and minimum temperatures. For a station located in Pacific Time (US), UTC time places the daily minimum \"in\" the day prior because UTC is 8 hours ahead of Pacific! The handy `convert_to_local_time` function corrects for this, and ensures that the resulting high and low temperatures are within the same daily timestamp. "
    ]
   },
   {
@@ -156,6 +158,26 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "05af9089-d21b-4611-a91e-bfa14948fb9a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "heatidx_hist_hour = convert_to_local_time(heatidx_hist_hour, selections)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6724a205-a8e4-4fcc-9c76-d144677e7169",
+   "metadata": {},
+   "source": [
+    "Now, we'll use the latitude and longitude values to retrieve the historical data at that gridcell. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "55e25ddd-b933-4b75-bcbe-31ecdb44b82a",
    "metadata": {},
    "outputs": [],
@@ -168,14 +190,16 @@
    "id": "753706c6-85b7-4965-ae4e-ec884bd24d5f",
    "metadata": {},
    "source": [
-    "Next, load the data into memory. Because we are loading and computing on the entire dataset, this will take about 5 minutes, hang tight!"
+    "Last, we load the data into memory. Because we are loading and computing on the entire dataset, this will take about 8 minutes, hang tight!"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "77dd5ea4-511a-4544-afee-896820f81a89",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "heatidx_hist_hour = ck.load(heatidx_hist_hour)"
@@ -214,10 +238,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c3645ba5-3533-4cda-95ff-801f9f709d5e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "heatidx_proj_hour = selections.retrieve()\n",
+    "heatidx_proj_hour = convert_to_local_time(heatidx_proj_hour, selections)\n",
     "heatidx_proj_hour = get_closest_gridcell(heatidx_proj_hour, stn_lat, stn_lon)"
    ]
   },
@@ -233,7 +260,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "17a332fd-e672-40c8-aea3-815640453153",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "heatidx_proj_hour = ck.load(heatidx_proj_hour)"
@@ -459,7 +488,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "aae3000e-14c5-4c3f-8efe-0fb68dcfd4bd",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hi_threshold = 91"
@@ -539,7 +570,7 @@
     "Next we'll look specifically at nighttime temperatures in order to assess when it may be too hot outside for worker safety and for assets to cool down. \n",
     "\n",
     "### 3a) Subset for nighttime hours\n",
-    "First, let's subset our hourly Heat Index data specifically for the nighttime hours. We will use 8pm-6am as \"nighttime\", but you can modify based on your needs as well. **Note:** The WRF data on the Cal-Adapt: Analytics Engine is in UTC time, and not in the local timezone. Timezone conversion functionality is currently in development and this notebook will be updated once available. For reference, California is -8 UTC (or -7 UTC when in Daylight Savings)."
+    "First, let's subset our hourly Heat Index data specifically for the nighttime hours. We will use 8pm-6am as \"nighttime\", but you can modify based on your needs as well."
    ]
   },
   {
@@ -551,11 +582,7 @@
    },
    "outputs": [],
    "source": [
-    "# help for modifications \n",
-    "# 8pm Pacific is 3am UTC (0300 UTC), which is index 2\n",
-    "# 6am Pacific is 1pm UTC (1300 UTC), which is index 12\n",
-    "\n",
-    "night_subset = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] # currently in UTC time\n",
+    "night_subset = [20, 21, 22, 23, 0, 1, 2, 3, 4, 5, 6] # 24 hour time\n",
     "heatidx_hist_nighthours = heatidx_hist_hour.isel(time=heatidx_hist_hour.time.dt.hour.isin(night_subset))"
    ]
   },
@@ -565,7 +592,7 @@
    "metadata": {},
    "source": [
     "### 3b) Sum the number of nighttime hours above a threshold of 80°F per day and per year\n",
-    "Like what we did above in Step 2a and 2b, we'll sum the nighttime Heat Index values for analysis. We'll use the same threshold as above, 80°F. But you can modify easily by setting this to any value of interest."
+    "Like what we did above in Step 2a and 2b, we'll sum the nighttime Heat Index values for analysis. We'll use the same threshold as above, 91°F. But you can modify easily by setting this to any value of interest."
    ]
   },
   {
@@ -733,8 +760,8 @@
    "outputs": [],
    "source": [
     "# month_subset = [5, 6, 7, 8, 9] # May, June, July, August, September\n",
-    "# heatidx_hist_hour = heatidx_hist_day.isel(time = heatidx_hist_day.time.dt.month.isin(month_subset)) # historical\n",
-    "# heatidx_proj_hour = heatidx_proj_day.isel(time = heatidx_proj_day.time.dt.month.isin(month_subset)) # future"
+    "# heatidx_hist_day = heatidx_hist_day.isel(time = heatidx_hist_day.time.dt.month.isin(month_subset)) # historical\n",
+    "# heatidx_proj_day = heatidx_proj_day.isel(time = heatidx_proj_day.time.dt.month.isin(month_subset)) # future"
    ]
   },
   {
@@ -769,7 +796,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "18c25ba3-4c3d-4207-b942-ad4a6a432e71",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "ck.view(heatidx_proj_day)"

--- a/collaborative/IOU/heat_index.ipynb
+++ b/collaborative/IOU/heat_index.ipynb
@@ -51,7 +51,7 @@
     "## Step 1: Select data\n",
     "\n",
     "### 1a) Grab location of interest by latitude and longitude\n",
-    "First we'll grab specific locations of interest, by using the latitude and longitudeconvert_to_local_timeions of a weather station, and provide code to input a custom lat-lon location. Furthermore, we will **not** be retrieving the actual station data that is bias-corrected to that station for this example. At present bias-corrected station data on the Analytics Engine only provides air temperature as a variable, and for Heat Index we must also have either dew point temperature (coming soon!) or relative humidity. So for the time being, we will retrieve **non-bias corrected** data at the location of interest."
+    "First we'll grab specific locations of interest, by using the latitude and longitude locations of a weather station, and provide code to input a custom lat-lon location. Furthermore, we will **not** be retrieving the actual station data that is bias-corrected to that station for this example. At present bias-corrected station data on the Analytics Engine only provides air temperature as a variable, and for Heat Index we must also have either dew point temperature (coming soon!) or relative humidity. So for the time being, we will retrieve **non-bias corrected** data at the location of interest."
    ]
   },
   {


### PR DESCRIPTION
Adds the `convert_to_local_time` correction to the heat_index and annual_consumption_model notebooks as they use hourly data that require daily min/maxes being on the "correct" timestamp for that day. 

----
**To Test**
Run these two notebooks, at least up to the timezone correction