### PR TITLE
Upgrading `agnostic_tools.ipynb`

### DIFF
--- a/work_in_progress/agnostic_tools.ipynb
+++ b/work_in_progress/agnostic_tools.ipynb
@@ -50,7 +50,8 @@
     "    plot_climate_response_LOCA,\n",
     "    show_available_vars,\n",
     "    get_available_units,\n",
-    ")"
+    ")\n",
+    "import numpy as np"
    ]
   },
   {
@@ -205,9 +206,9 @@
    "source": [
     "### Step 1: Identify parameters and location of interest\n",
     "\n",
-    "Below, please enter the desired parameters for exploring the distribution amongst LOCA2-Hybrid or WRF simulations.\n",
+    "Below, we offer example default settings to set-up the Simulation Explorer Tool. You can also customize these paramaters, including month, years, downscaling method (\"Dynamical\" or \"Statistical\").\n",
     "\n",
-    "**If you are looking at WRF simulations and you want to quickly view 4 monthly-aggregated WRF simulations, you can run the cell as is, but if you want to see the full 8 hourly-aggregated WRF simulations, change the timescale parameter to `hourly` instead of `monthly`. The rest of the notebook should take ~45 min. instead if you decide to do so.**"
+    "**Note**: If you use the default downscaling method of \"Dynamical\" to analyze WRF data, the timescale is set ot a default of monthly. This retrieves the 4 monthly-aggregated simulations and takes approximately 1-2 minutes to run. However, if you would like to look at all 8 available models, set `wrf_timescale` to \"hourly\"; the notebook will take much longer to run (~45 minutes) as it has to compute a much larger dataset!"
    ]
   },
   {
@@ -217,19 +218,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "### Change these parameters to your choosing\n",
-    "\n",
     "# Months desired for analysis, Jan = 1\n",
     "months = range(1, 13)\n",
     "\n",
     "# Years desired for analysis, inclusive\n",
     "years = (2013, 2040)\n",
     "\n",
-    "# Change this method to describe if you'd like to examine LOCA2-Hybrid or WRF simulations\n",
+    "# Options are: \"Dynamical\" (WRF) or \"Statistical\" (LOCA2-Hybrid)\n",
     "downscaling_method = 'Dynamical'\n",
     "\n",
-    "# Change this to 'monthly' if you'd rather have a quick aggregation of 4 WRF simulations.\n",
-    "wrf_timescale = 'monthly'\n",
+    "# Options are: \"monthly\" (4 monthly-aggregated WRF models) or \"hourly\" (8 hourly WRF models -- time intensive!)\n",
+    "wrf_timescale = 'hourly'\n",
     "\n",
     "# This shows the available variables for your inputs\n",
     "show_available_vars(downscaling_method, wrf_timescale)"
@@ -239,15 +238,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "200d0d1f-fca8-4e78-93c8-99ae1671e0c7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Input desired variable\n",
-    "variable = 'Air Temperature at 2m' # REPLACE HERE\n",
+    "variable = 'Air Temperature at 2m' # change variable if so desired HERE\n",
     "\n",
-    "# Select desired aggregation function\n",
-    "import numpy as np\n",
-    "agg_func = np.mean # np.median\n",
+    "# Select desired aggregation function (another option is \"np.median\")\n",
+    "agg_func = np.mean\n",
     "\n",
     "# Select latitude and longitude range; replace with individual numbers if you're only looking for a specific lat/lon point\n",
     "lat_range = (32.58, 33.20)\n",
@@ -255,7 +255,7 @@
     "\n",
     "# Select your desired units\n",
     "print(get_available_units(variable, downscaling_method))\n",
-    "units = 'K' # FILL HERE"
+    "units = 'K' # change unit if so desired HERE"
    ]
   },
   {
@@ -271,14 +271,16 @@
    "id": "73f77913-1827-4b62-a213-1391640e63a7",
    "metadata": {},
    "source": [
-    "With the below function, we can look at the distribution of either LOCA2-Hybrid or WRF simulations for a gridcell at a specific lat/lon. This will run <1 min. for WRF simulations to calculate all the aggregations, but can take up to ~5 min. for LOCA2-Hybrid simulations. Hang tight!"
+    "With the below function, we can look at the distribution for a gridcell at a specific lat/lon. For WRF data, the will take between 1-3 min. For LOCA2-Hybrid data, this can take up to ~5 min."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "fa453eea-ea45-4b60-a9c8-db83ea1cddcf",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -290,14 +292,16 @@
    "id": "11713e44-5b57-4664-92aa-1fbecdda299e",
    "metadata": {},
    "source": [
-    "With this below function, we can look at the distribution of simulations across a selected metric for the state of California. If you are using WRF data, this calculation should take around the same amount of time as the one above. However, if you are using LOCA2-Hybrid data, this calculation will take a bit longer than the one above (~20 min.). Run the cell, go refill some water, take a break, and come back in about 20 minutes."
+    "With this below function, we can look at the distribution of simulations across a selected metric for the state of California. If you are using WRF data, this calculation should take around the same amount of time as the one above. However, if you are using LOCA2-Hybrid data, this calculation will take a bit longer than the one above (~20 min.)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "56d38026-1496-44e6-ac80-18b68fe20549",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -403,7 +407,9 @@
     "variable2 = 'Precipitation (total)'\n",
     "units2 = 'mm'\n",
     "single_stats_gridcell2, multiple_stats_gridcell2, results_gridcell2 = agg_lat_lon_sims(lat_range, lon_range, downscaling_method, variable2, agg_func, units2, years, months)\n",
-    "# single_stats_area2, multiple_stats_area2, results_area2 = agg_area_subset_sims(area_subset, selected_area, downscaling_method, variable2, agg_func, units2, years, months)\n"
+    "\n",
+    "## alternative version, if using an aggregated area instead of a single gridcell selection\n",
+    "# single_stats_area2, multiple_stats_area2, results_area2 = agg_area_subset_sims(area_subset, selected_area, downscaling_method, variable2, agg_func, units2, years, months)"
    ]
   },
   {
@@ -421,7 +427,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## Plotting distribution of simulations based on if your downscaling method was 'Dynamical' (WRF) or 'Statistical' (LOCA2-Hybrid).\n",
+    "# Plotting distribution of simulations based on if your downscaling method was 'Dynamical' (WRF) or 'Statistical' (LOCA2-Hybrid).\n",
     "if downscaling_method == 'Dynamical':\n",
     "    plot_WRF(results_gridcell, agg_func, years)\n",
     "elif downscaling_method == 'Statistical':\n",
@@ -440,10 +446,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "35af05d1-655b-480b-8cd4-81a634439a2d",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "## Plotting 2 climate metrics against each other based on if your downscaling method was 'Dynamical' (WRF) or 'Statistical' (LOCA2-Hybrid).\n",
+    "# Plotting 2 climate metrics against each other based on if your downscaling method was 'Dynamical' (WRF) or 'Statistical' (LOCA2-Hybrid).\n",
     "if downscaling_method == 'Dynamical':\n",
     "    plot_climate_response_WRF(results_gridcell, results_gridcell2)\n",
     "elif downscaling_method == 'Statistical':\n",

--- a/work_in_progress/agnostic_tools.ipynb
+++ b/work_in_progress/agnostic_tools.ipynb
@@ -294,14 +294,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "86491e8e-3112-4f04-a028-c0848627e003",
-   "metadata": {},
-   "source": [
-    "# Default to smaller WRF selection first"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "56d38026-1496-44e6-ac80-18b68fe20549",

--- a/work_in_progress/agnostic_tools.ipynb
+++ b/work_in_progress/agnostic_tools.ipynb
@@ -228,7 +228,7 @@
     "downscaling_method = 'Dynamical'\n",
     "\n",
     "# Options are: \"monthly\" (4 monthly-aggregated WRF models) or \"hourly\" (8 hourly WRF models -- time intensive!)\n",
-    "wrf_timescale = 'hourly'\n",
+    "wrf_timescale = 'monthly'\n",
     "\n",
     "# This shows the available variables for your inputs\n",
     "show_available_vars(downscaling_method, wrf_timescale)"

--- a/work_in_progress/agnostic_tools.ipynb
+++ b/work_in_progress/agnostic_tools.ipynb
@@ -207,7 +207,7 @@
     "\n",
     "Below, please enter the desired parameters for exploring the distribution amongst LOCA2-Hybrid or WRF simulations.\n",
     "\n",
-    "**If you are looking at WRF simulations and you want to quickly view 4 monthly-aggregated WRF simulations, you can run the cell as is, but if you want to see the full 8 hourly-aggregated WRF simulations, change the timescale parameter to `hourly` instead of `monthly`.**"
+    "**If you are looking at WRF simulations and you want to quickly view 4 monthly-aggregated WRF simulations, you can run the cell as is, but if you want to see the full 8 hourly-aggregated WRF simulations, change the timescale parameter to `hourly` instead of `monthly`. The rest of the notebook should take ~45 min. instead if you decide to do so.**"
    ]
   },
   {

--- a/work_in_progress/agnostic_tools.ipynb
+++ b/work_in_progress/agnostic_tools.ipynb
@@ -58,6 +58,7 @@
    "cell_type": "markdown",
    "id": "2c77cda9-755f-46a9-8fd6-9a6789fb6be6",
    "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
     "tags": []
    },
    "source": [
@@ -206,9 +207,11 @@
    "source": [
     "### Step 1: Identify parameters and location of interest\n",
     "\n",
-    "Below, we offer example default settings to set-up the Simulation Explorer Tool. You can also customize these paramaters, including month, years, downscaling method (\"Dynamical\" or \"Statistical\").\n",
+    "Below, we offer an example of default settings to set-up the Simulation Explorer Tool. You can also customize these parameters, including months, years, and downscaling method (\"Dynamical\" or \"Statistical\").\n",
     "\n",
-    "**Note**: If you use the default downscaling method of \"Dynamical\" to analyze WRF data, the timescale is set ot a default of monthly. This retrieves the 4 monthly-aggregated simulations and takes approximately 1-2 minutes to run. However, if you would like to look at all 8 available models, set `wrf_timescale` to \"hourly\"; the notebook will take much longer to run (~45 minutes) as it has to compute a much larger dataset!"
+    "**Note**: If you use the default downscaling method of \"Dynamical\" to analyze WRF data, the timescale is set to monthly by default. This retrieves the 4 monthly-aggregated simulations and takes approximately 1-2 minutes to run. However, if you would like to look at all 8 available models, set `wrf_timescale` to \"hourly\"; the notebook will take much longer to run (~45 minutes) as it has to compute a much larger dataset!\n",
+    "\n",
+    "If you select the \"Statistical\" downscaling method for analyzing LOCA2-Hybrid data, the timescale can only be monthly, because of how computationally-heavy it is to aggregate on more granular timescales."
    ]
   },
   {
@@ -227,7 +230,8 @@
     "# Options are: \"Dynamical\" (WRF) or \"Statistical\" (LOCA2-Hybrid)\n",
     "downscaling_method = 'Dynamical'\n",
     "\n",
-    "# Options are: \"monthly\" (4 monthly-aggregated WRF models) or \"hourly\" (8 hourly WRF models -- time intensive!)\n",
+    "# Options are: \"monthly\" (4 monthly-aggregated WRF models),  or \"hourly\" (8 hourly WRF models -- time intensive!)\n",
+    "# Ignore this line if you are just using 'Statistical' data\n",
     "wrf_timescale = 'monthly'\n",
     "\n",
     "# This shows the available variables for your inputs\n",
@@ -292,16 +296,14 @@
    "id": "11713e44-5b57-4664-92aa-1fbecdda299e",
    "metadata": {},
    "source": [
-    "With this below function, we can look at the distribution of simulations across a selected metric for the state of California. If you are using WRF data, this calculation should take around the same amount of time as the one above. However, if you are using LOCA2-Hybrid data, this calculation will take a bit longer than the one above (~20 min.)."
+    "With the next function below, we can look at the distribution of simulations across a selected metric for the state of California. If you are using WRF data, this calculation should take around the same amount of time as the one above. However, if you are using LOCA2-Hybrid data, this calculation will take a bit longer than the one above (~20 min.)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56d38026-1496-44e6-ac80-18b68fe20549",
-   "metadata": {
-    "tags": []
-   },
+   "id": "5667f859-e666-431f-bdac-945cf03f0def",
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%time\n",
@@ -408,7 +410,7 @@
     "units2 = 'mm'\n",
     "single_stats_gridcell2, multiple_stats_gridcell2, results_gridcell2 = agg_lat_lon_sims(lat_range, lon_range, downscaling_method, variable2, agg_func, units2, years, months)\n",
     "\n",
-    "## alternative version, if using an aggregated area instead of a single gridcell selection\n",
+    "## alternative version, if you are using an aggregated area instead of a single gridcell selection\n",
     "# single_stats_area2, multiple_stats_area2, results_area2 = agg_area_subset_sims(area_subset, selected_area, downscaling_method, variable2, agg_func, units2, years, months)"
    ]
   },
@@ -453,9 +455,11 @@
    "source": [
     "# Plotting 2 climate metrics against each other based on if your downscaling method was 'Dynamical' (WRF) or 'Statistical' (LOCA2-Hybrid).\n",
     "if downscaling_method == 'Dynamical':\n",
-    "    plot_climate_response_WRF(results_gridcell, results_gridcell2)\n",
+    "    plot = plot_climate_response_WRF(results_gridcell, results_gridcell2)\n",
     "elif downscaling_method == 'Statistical':\n",
-    "    plot_climate_response_LOCA(results_gridcell, results_gridcell2)"
+    "    plot = plot_climate_response_LOCA(results_gridcell, results_gridcell2)\n",
+    "    \n",
+    "display(plot)"
    ]
   }
  ],


### PR DESCRIPTION
The following changes should be observed in this PR:

1. 8 hourly WRF sims vs 4 monthly WRF sims observed in gridcell aggregations in the latter plots. This is mainly seen through the usage of the `wrf_timescale` variable being `monthly` vs `hourly`.
2. Climate response plot being rendered as an hvplot, allowing users to toggle specific GCMs or simulations, depending on which type of downscaling method is used.
3. The total runtime text is added at the top of the notebook for users to be aware of how long the notebook should take on default settings.

Associated back-end changes in https://github.com/cal-adapt/climakitae/pull/344/files.