### PR TITLE
Making slight modifications to vulnerability notebook to accomodate for vul_table inclusion

### DIFF
--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -279,7 +279,7 @@
    "id": "9c558433-b9c2-4b3a-b001-cce58c9067e0",
    "metadata": {},
    "source": [
-    "Below, you'll find code that generates a table with different climate data metrics used in a CAVA Report. Feel free to run it and check it out! It is still very much in progress."
+    "Below, you'll find code that generates a table with different climate data metrics used in a CAVA Report. Feel free to run it and check it out! It is still very much in progress. **This will take > 30 min. to run.**"
    ]
   },
   {

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -29,10 +29,6 @@
    },
    "outputs": [],
    "source": [
-    "import climakitae as ck\n",
-    "import pandas as pd\n",
-    "import xarray as xr\n",
-    "\n",
     "from climakitae.explore.vulnerability import cava_data"
    ]
   },
@@ -289,21 +285,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81e1889d-c155-4d36-b134-abaafd7bf711",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from climakitae.explore.vulnerability_table import create_vul_table"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "6c35d388-1989-4716-8c9f-d78f435c9bb7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = create_vul_table(example_locs.iloc[10])"
+    "%%time\n",
+    "percentile = 50\n",
+    "heat_idx_threshold = 80\n",
+    "one_in_x = 10 # currently, only can do `one_in_x` for one value at a time\n",
+    "df = create_vul_table(example_locs.iloc[[10]], percentile, heat_idx_threshold, one_in_x)"
    ]
   }
  ],

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -293,7 +293,8 @@
     "percentile = 50\n",
     "heat_idx_threshold = 80\n",
     "one_in_x = 10 # currently, only can do `one_in_x` for one value at a time\n",
-    "df = create_vul_table(example_locs.iloc[[10]], percentile, heat_idx_threshold, one_in_x)"
+    "df = create_vul_table(example_locs.iloc[[10]], percentile, heat_idx_threshold, one_in_x)\n",
+    "df",
    ]
   }
  ],

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -294,7 +294,7 @@
     "heat_idx_threshold = 80\n",
     "one_in_x = 10 # currently, only can do `one_in_x` for one value at a time\n",
     "df = create_vul_table(example_locs.iloc[[10]], percentile, heat_idx_threshold, one_in_x)\n",
-    "df",
+    "df"
    ]
   }
  ],

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -279,7 +279,7 @@
    "id": "9c558433-b9c2-4b3a-b001-cce58c9067e0",
    "metadata": {},
    "source": [
-    "Below, you'll find code that generates a table with different climate data metrics used in a CAVA Report. Feel free to run it and check it out! It is still very much in progress. **This will take > 30 min. to run.**"
+    "Below, you'll find code that generates a table with different climate data metrics used in a CAVA Report. Feel free to run it and check it out! It is still very much in progress. **This will take 30+ min. to run.**"
    ]
   },
   {


### PR DESCRIPTION
This PR removes redundant imports and adds optionality for users to plug in specified thresholds into the `create_vul_table` function.