### PR TITLE
TMY notebook: update rad units to W/m2, fix markdown typo

### DIFF
--- a/work_in_progress/typical_meteorological_year_methodology.ipynb
+++ b/work_in_progress/typical_meteorological_year_methodology.ipynb
@@ -134,7 +134,7 @@
    "metadata": {},
    "source": [
     "#### Step 1b: Variables in catalog\n",
-    "When selecting data, there are several considerations to be aware of. The recommended minimum input of data is 15-20 years worth of daily data. First, we will pre-load some data options to ensure that the same constraints are applied to every variable we retrieve from the catalog and calculate. It is important to note that not all models in the Cal-Adapt: Analytics Engine have the solar variables critical for TMY file generation - in fact, only 4 do! We will carefully subset our variables to ensure that the same 4 models are selected for consistency. We will also process the data for our designated station location (latitude, and longitude) at 45 km over the 1990-2020 period. For data post-2014, we will utilize SSP 3-7.0, although scenario selection in the near-future is relatively independent. If calculating a TMY for the far-future, **carefully consider which scenario SSP to include**, as there will be **significant** differences present. \n",
+    "When selecting data, there are several considerations to be aware of. The recommended minimum input of data is 15-20 years worth of daily data. First, we will pre-load some data options to ensure that the same constraints are applied to every variable we retrieve from the catalog and calculate. It is important to note that not all models in the Cal-Adapt: Analytics Engine have the solar variables critical for TMY file generation - in fact, only 4 do! We will carefully subset our variables to ensure that the same 4 models are selected for consistency. We will also process the data for our designated station location (latitude, and longitude) at 9 km over the 1990-2020 period. For data post-2014, we will utilize SSP 3-7.0, although scenario selection in the near-future is relatively independent. If calculating a TMY for the far-future, **carefully consider which scenario SSP to include**, as there will be **significant** differences present. \n",
     "\n",
     "Lastly, because the dynamically downscaled WRF data in the Cal-Adapt: Analytics Engine is in UTC time, we'll convert to the timezone of the station we've selected. This is particularly important for the timing of solar radiation max and min, which is a critical piece of a TMY. The handy `convert_to_local_time` function corrects for this, and ensures that all data within the same daily timestamp."
    ]
@@ -833,10 +833,10 @@
     "        'Air Temperature at 2m':'degC',\n",
     "        'Dew point temperature':'degC',\n",
     "        'Relative humidity':'[0 to 100]', \n",
-    "        'Instantaneous downwelling shortwave flux at bottom':'W m-2',\n",
-    "        'Shortwave surface downward direct normal irradiance':'W m-2',  \n",
-    "        'Shortwave surface downward diffuse irradiance':'W m-2',\n",
-    "        'Instantaneous downwelling longwave flux at bottom':'W m-2',\n",
+    "        'Instantaneous downwelling shortwave flux at bottom':'W/m2',\n",
+    "        'Shortwave surface downward direct normal irradiance':'W/m2',  \n",
+    "        'Shortwave surface downward diffuse irradiance':'W/m2',\n",
+    "        'Instantaneous downwelling longwave flux at bottom':'W/m2',\n",
     "        'Wind speed at 10m':'m s-1',\n",
     "        'Wind direction at 10m':'degrees',\n",
     "        'Surface Pressure':'Pa'\n",
@@ -995,7 +995,7 @@
    "source": [
     "for sim, tmy in tmy_data_to_export.items():\n",
     "    filename = 'TMY_{0}_{1}'.format(stn_name.replace(\" \", \"_\").replace(\"(\",\"\").replace(\")\",\"\"), sim).lower()\n",
-    "    write_tmy_file(filename, tmy_data_to_export[sim], stn_name, stn_code, stn_lat, stn_lon, stn_state, file_ext=\"tmy\")"
+    "    write_tmy_file(filename, tmy_data_to_export[sim], stn_name, stn_code, stn_lat, stn_lon, stn_state, stn_elev, file_ext=\"epw\")"
    ]
   }
  ],


### PR DESCRIPTION
1. Updates the unit selection for the two radiation variables in the full TMY data retrieval function as units were updated in climakitae from "W m-2" to "W/m2"
2. Fixes a typo in the markdown referencing 45 km data when 9 km data is actually used. 