### PR TITLE
update markdown table for HI wrf only + 2.5 WL in progress

### DIFF
--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -126,9 +126,9 @@
     "|time_end_year | Numerical (max is 2100) | Required for **approach=time**| |\n",
     "|historical_data| \"Historical Climate\", \"Historical Reconstruction\" | Required for **approach=time**| **Historical Climate** ranges from 1980-2015 for WRF and 1950-2015 for LOCA2-Hybrid. **Historical Reconstruction** ranges from 1950-2022.|\n",
     "|ssp_data | \"[SSP2-4.5]\", \"[SSP3-7.0]\", \"[SSP5-8.5]\" | Required for **approach=time** | Dynamical only has SSP3-7.0, Statisical has all 3 SSP options|\n",
-    "|warming_level| \"1.5\", \"2.0\", \"3.0\" | Required for **approach=warming_level**| |\n",
+    "|warming_level| \"1.5\", \"2.0\", \"3.0\" | Required for **approach=warming_level**| *In progress option for \"2.5\"*|\n",
     "|metric_calc| \"max\", \"min\" | Required for 1-in-X temp, Heat Index, likely seasonal event | |\n",
-    "|heat_idx_threshold | Numerical | Required for Heat Index | |\n",
+    "|heat_idx_threshold | Numerical | Required for Heat Index | Heat Index can only be calculated with **downscaling_method=\"Dynamical\"**|\n",
     "|one_in_x | Numerical | Required for 1-in-X temp| |\n",
     "|percentile | Numerical (0-100) | Required for likely seasonal event |   |\n",
     "|season| \"summer\", \"winter\", \"all\" | Required for likely seasonal event| Default set to \"all\"|\n",
@@ -178,18 +178,6 @@
     "    export_method=\"calculate\",  # export only calculated metric data\n",
     "    file_format=\"NetCDF\",\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7e3c2c7b-fbe6-4242-be12-2e1fecec1a9c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import xarray as xr\n",
-    "test = xr.open_dataset('likely_seasonal_summer_max_2030 to 2050_3543424N_-11905524W.nc')\n",
-    "test"
    ]
   },
   {
@@ -293,7 +281,7 @@
     "    approach=\"warming_level\",\n",
     "    warming_level=\"2.0\",\n",
     "    \n",
-    "    ## Likely seaonal event specific arguments\n",
+    "    ## Likely seasonal event specific arguments\n",
     "    variable=\"Air Temperature at 2m\", \n",
     "    metric_calc=\"max\", # daily high temperature\n",
     "    percentile=60, # likeliness percentile\n",


### PR DESCRIPTION
Updates markdown table of options:
- Heat index can only be calculated with WRF (LOCA does not have the variables and is not hooked up to calculation)
- Based on CPUC guidance, adding 2.5°C as in progress option for WL
- Fix a typo