### PR TITLE
Add new notebook to showcase new data access options from climakitae PR #398

### DIFF
--- a/AE_navigation_guide.ipynb
+++ b/AE_navigation_guide.ipynb
@@ -32,11 +32,13 @@
     "tags": []
    },
    "source": [
-    "### Get Started with the Analytics Engine\n",
-    "-----------------------------------------\n",
-    "[getting_started.ipynb](getting_started.ipynb): Introduction to retrieving, visualizing, and exporting climate data using python and the Analytics Engine.<br>*For example: What data is available on the Analytics Engine?*\n",
+    "### Accessing data and getting started with the Analytics Engine\n",
+    "-------------------------------------------------------------------\n",
+    "[getting_started.ipynb](getting_started.ipynb): Introduction to retrieving, visualizing, and exporting climate data using python and the Analytics Engine. This notebook features an interactive graphical user interface (GUI) that makes viewing the available data options simple and intuitive. <br>*For example: What data is available on the Analytics Engine?*\n",
     "\n",
-    "[catalog_access_and_download.ipynb](catalog_access_and_download.ipynb): Overview to accessing and exporting climate data using python and the Analytics Engine data catalog.<br>*For example: How do I download raw climate data directly from the catalog?*\n",
+    "[climakitae_direct_data_download.ipynb](climakitae_direct_data_download.ipynb): Overview to accessing and exporting climate data from the AE catalog using helper functions in `climakitae`. These functions enable you to perform spatial subsetting when downloading the data using `climakitae`'s many geometry options, such as county, state, or watershed. <br>*For example: What are the Analytic Engine's command line options for viewing data options, downloading climate data, and performing spatial subsetting without using a GUI?*\n",
+    "\n",
+    "[intake_direct_data_download.ipynb](intake_direct_data_download.ipynb): Overview to accessing and exporting climate data from the AE catalog using the python library `intake`.<br>*For example: How do I download raw climate data directly from the catalog without using climakitae or a GUI?*\n",
     "\n",
     "### Exploratory Notebooks\n",
     "------------------------------------------\n",
@@ -80,6 +82,14 @@
     "\n",
     "[agnostic_tools.ipynb](work_in_progress/agnostic_tools.ipynb): Introduction to model agnostic tool development for model selection based on a set of preformulated metrics.<br>*For example: What is the projected warming level in the year 2050 based on all available model simulations?*"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ffa65da",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -98,7 +108,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/climakitae_direct_data_download.ipynb
+++ b/climakitae_direct_data_download.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "811929f5-5aaf-4c4c-af1c-0c63bd51961e",
+   "metadata": {},
+   "source": [
+    "Pythonic data access using climakitae \n",
+    "--------------------------------------\n",
+    "This notebook showcases helper functions from `climakitae` that enable you to access the AE catalog data **without** using a GUI, while also allowing you to perform spatial subsetting and view the data options in an easy-to-use fashion. These functions could be easily implemented in a python script. <br>\n",
+    "\n",
+    "As a reminder, you can access the data using one of the following methods: \n",
+    "1) the climakitae Selections GUI ([getting_started.ipynb](getting_started.ipynb))\n",
+    "2) using helper functions in the `climakitae` library (this notebook!) \n",
+    "3) the python library `intake` ([intake_direct_data_download.ipynb](intake_direct_data_download.ipynb))\n",
+    "<br>\n",
+    "\n",
+    "This notebook showcases option 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1559cdbd-edd2-4c77-a61c-428159453a04",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from climakitae.core.data_interface import (\n",
+    "    get_data_options, \n",
+    "    get_subsetting_options, \n",
+    "    get_data\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1750153d-4aec-4011-8345-9ceb5d9e2fa8",
+   "metadata": {},
+   "source": [
+    "## See all the data options in the catalog \n",
+    "These options will match those in our AE selections GUI. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a4da135-f64c-415e-a03b-0863cd67bd99",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data_options()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13ed137e-c478-4401-beeb-8bfd5d12f45f",
+   "metadata": {},
+   "source": [
+    "## See the data options for a particular subset of inputs\n",
+    "The `get_data_options` function enables you to input a number of different function arguments, corresponding to the columns in the table above, to subset the table. Inputting no arguments, like we did above, will return the entire range of options.<br><br>First, lets print the function documentation to see the inputs and outputs of the function. If an argument (or \"parameter\", as listed in the documentation) is listed as \"optional\", that means you don't have to input anything for that argument. In the case of this function, none of the function arguments are required, so you can simply call the function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c193f9f-c154-413f-92dc-084d2ea05ae7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(get_data_options.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9c1e03c-a414-4b5b-94d3-1ec2b01573a1",
+   "metadata": {},
+   "source": [
+    "If you call the function with **no inputs**, it will simply return the entire catalog! But, let's say you want to see all the data options for statistically downscaled data at 3 km resolution. You'll want to provide inputs for the `downscaling_method` and `resolution` arguments. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bf820b0-9940-4ec9-b8d4-ad9e8cd4cb9c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data_options(\n",
+    "    downscaling_method = \"Statistical\", \n",
+    "    resolution = \"3 km\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a222cad5-89cd-4ec2-8b76-fca3f764e247",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-12T17:42:00.445033Z",
+     "iopub.status.busy": "2024-07-12T17:42:00.444642Z",
+     "iopub.status.idle": "2024-07-12T17:42:00.482082Z",
+     "shell.execute_reply": "2024-07-12T17:42:00.480999Z",
+     "shell.execute_reply.started": "2024-07-12T17:42:00.445010Z"
+    }
+   },
+   "source": [
+    "Perhaps you want to see all the data options for daily precipitation. We have several precipitation options in the catalog. You don't need to know the name of these variables; simply use \"precipitation\" as your input to the function for the `variable` argument.<br><br>The function prefers that your inputs match an actual option in the catalog-- with exact capitalizations and no misspelling-- and will print a warning if your input is not a direct match (\"precipitation\" is not an option, but \"Precipitation (total)\" is). The function will then try to make a guess as to what you actually meant. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7fae3993-ead4-49d8-87ad-066ec5c3181f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data_options(\n",
+    "    variable = \"precipitation\", \n",
+    "    timescale = \"daily\"\n",
+    ") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f8260ed-adff-4c49-86ff-69ec207da04d",
+   "metadata": {},
+   "source": [
+    "The function can also return a simple pandas DataFrame without the complex MultiIndex. Just set `tidy = False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66582be5-eb9a-42b8-ae08-e96ffa671195",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data_options(\n",
+    "    variable = \"precipitation\", \n",
+    "    timescale = \"daily\", \n",
+    "    tidy = False\n",
+    ") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3f954d4-7a75-4dcd-b6d6-8e7d730fc607",
+   "metadata": {},
+   "source": [
+    "## See all the geometry options for spatially subsetting the data during retrieval\n",
+    "These options will match those in our AE selections GUI. This will enable you to retrieve a subset for a specific region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddc1fdd4-8bc2-4785-ace1-229ba168d54f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_subsetting_options()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "810fa239-8afb-4b20-b285-401fbaac40b4",
+   "metadata": {},
+   "source": [
+    "This shows a lot of options! Say you're only interested in California counties. Simply set the argument `area_subset` to \"CA counties\" to see the all options for counties. The function documentation shows the other options, which also match the values in the column \"area_subset\" in the table above. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb47d46e-1b5b-4105-bdad-e48aa50f93f0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(get_subsetting_options.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5c602c6-d462-4474-b56e-cdd609394c33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_subsetting_options(area_subset = \"CA counties\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd52eec3-afe7-4324-9c53-3861d39aafeb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-12T19:50:18.044997Z",
+     "iopub.status.busy": "2024-07-12T19:50:18.044611Z",
+     "iopub.status.idle": "2024-07-12T19:50:18.080969Z",
+     "shell.execute_reply": "2024-07-12T19:50:18.080035Z",
+     "shell.execute_reply.started": "2024-07-12T19:50:18.044969Z"
+    }
+   },
+   "source": [
+    "You can see all the options for subsetting, and their corresponding geometries, but you don't actually need to use the geometries for subsetting if you use climakitae's data retrieval function-- `get_catalog_data` -- explained in the next section. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "103e4200-1c7f-49d8-a6e8-0e9602366f85",
+   "metadata": {},
+   "source": [
+    "## Retrieve the data \n",
+    "You can easily retrieve the data using the following function. This function requires you to input values for the following arguments: \n",
+    "- variable (required)\n",
+    "- downscaling method (required)\n",
+    "- resolution (required)\n",
+    "- timescale (required)\n",
+    "\n",
+    "\n",
+    "The options for each can be found using the `get_data_options` function. If desired, you can also specify a unit conversion using the argument `units`.<br><br>By default, the function will return the entire spatial domain of the data. If you wish to spatially subset the data, you can supply the following arguments to the function: \n",
+    "- area_subset (optional) \n",
+    "- cached_area (required) \n",
+    "\n",
+    "You can also opt to perform an area average by setting `area_average = True`. The default is `False`. \n",
+    "\n",
+    "Details for the function are in the docstrings, printed below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d618321-6ecb-4656-8c9d-9d344d41b570",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "print(get_data.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b34cdd79-7854-4435-abcc-87258bd0a98b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Statistical\", \n",
+    "    resolution = \"3 km\", \n",
+    "    timescale = \"daily\", \n",
+    "    scenario = \"Historical Climate\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17617637-59ff-4248-b1c1-f56f9f6b7391",
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2024-07-12T21:48:10.459519Z",
+     "iopub.status.idle": "2024-07-12T21:48:10.460048Z",
+     "shell.execute_reply": "2024-07-12T21:48:10.459831Z",
+     "shell.execute_reply.started": "2024-07-12T21:48:10.459807Z"
+    }
+   },
+   "source": [
+    "Now say you're only interested in data for San Bernadino County, and you want to compute an area average over the entire county. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0c92a88-e9f9-41b4-b767-e2d07f5689b1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Statistical\", \n",
+    "    resolution = \"3 km\", \n",
+    "    timescale = \"daily\", \n",
+    "    scenario = \"Historical Climate\",\n",
+    "    cached_area = \"San Bernardino County\", \n",
+    "    area_average = \"Yes\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/intake_direct_data_download.ipynb
+++ b/intake_direct_data_download.ipynb
@@ -250,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This new notebook showcases options for viewing, retrieving, and performing spatial subsetting on AE data using climakitae but **without** using a GUI! It highlights this new functionality from climakitae PR [#398](https://github.com/cal-adapt/climakitae/pull/398). I also updated some text in the navigation guide to better explain the difference between some of the notebooks that do similar things, and renamed the `catalog_data_access_and_download.ipynb` notebook to better differentiate it from this new notebook. :D 

To review, please run the new notebook `climakitae_direct_data_download.ipynb` and review the text changes in `AE_navigation_guide.ipynb`. Also, any opinions on the names of the new notebook and the changed name of the `catalog_data_access_and_download.ipynb` notebook (renamed to `intake_direct_data_download.ipynb`) are welcome! 
