### PR TITLE
Upgrade `thresholds_basics.ipynb` to reduce spatial extent and increase user visibility into runtimes

### DIFF
--- a/work_in_progress/threshold_basics.ipynb
+++ b/work_in_progress/threshold_basics.ipynb
@@ -37,7 +37,7 @@
    "id": "af3f57a1-5452-4c1e-95e5-89d149c5dad5",
    "metadata": {},
    "source": [
-    "**Runtime**: With the default settings, this notebook takes approximately **35-45 minutes** to run from start to finish. Modifications to selections may increase the runtime. "
+    "**Runtime**: With the default settings, this notebook takes approximately **50-55 minutes** to run from start to finish. Modifications to selections may increase the runtime. "
    ]
   },
   {
@@ -194,7 +194,7 @@
    "outputs": [],
    "source": [
     "ams = threshold_tools.get_block_maxima(subsetted_data, extremes_type='max', check_ess=False)\n",
-    "ams = ck.load(ams, progress_bar=True) \n",
+    "ams = ck.load(ams)\n",
     "ams"
    ]
   },
@@ -286,7 +286,7 @@
    "id": "9f7af1ed-2a85-46cd-b301-b83de0fe6c84",
    "metadata": {},
    "source": [
-    "**Note:** The following cell takes ~20 minutes to run!"
+    "**Note:** Since we're running 100 bootstraps, this cell will take a while (~20 min.)!"
    ]
   },
   {
@@ -324,6 +324,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3f087edc-7669-4dfe-8979-eff834b951c3",
+   "metadata": {},
+   "source": [
+    "**Note:** Similarly here, we're also running 100 bootstraps in the backend to get the return probability from a bootstrapped distribution. This will take less time (~10 min.)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a65eb953-e638-4328-9268-89578770e3d3",
@@ -349,6 +357,14 @@
     "The `get_return_period` function in `threshold_tools` calculates the return period (i.e., 1-in-X-year) for a certain return value. Confidence intervals of the return periods can also be calculated.\n",
     "\n",
     "The example code calculates the return period of 300 Kelvin events. The return periods are inferred from Weibull distributions fitted to the AMS. By default, a hundred bootstrap samples are also used to calculate 95% confidence intervals."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e75154e-3b38-41f7-99dd-63bcc39179b5",
+   "metadata": {},
+   "source": [
+    "**Note:** Same note as above for `pearson3`. This will take ~10 min."
    ]
   },
   {

--- a/work_in_progress/threshold_basics.ipynb
+++ b/work_in_progress/threshold_basics.ipynb
@@ -34,6 +34,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "af3f57a1-5452-4c1e-95e5-89d149c5dad5",
+   "metadata": {},
+   "source": [
+    "**Runtime**: With the default settings, this notebook takes approximately **35-45 minutes** to run from start to finish. Modifications to selections may increase the runtime. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "75e715a2-8aa5-4d1d-8ac1-3819d136136f",
    "metadata": {
     "id": "75e715a2-8aa5-4d1d-8ac1-3819d136136f",
@@ -93,6 +101,9 @@
    "outputs": [],
    "source": [
     "selections = ckg.Select()\n",
+    "selections.area_subset = 'states'\n",
+    "selections.cached_area = ['CA']\n",
+    "selections.resolution = '45 km'\n",
     "selections.show()"
    ]
   },
@@ -120,18 +131,6 @@
    "outputs": [],
    "source": [
     "generated_data = selections.retrieve()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a83e3d37-6d65-45c9-b137-08a4c2e07218",
-   "metadata": {
-    "id": "a83e3d37-6d65-45c9-b137-08a4c2e07218"
-   },
-   "outputs": [],
-   "source": [
-    "generated_data"
    ]
   },
   {
@@ -194,8 +193,8 @@
    },
    "outputs": [],
    "source": [
-    "ams = threshold_tools.get_block_maxima(subsetted_data, extremes_type='max')\n",
-    "ams = ck.load(ams) \n",
+    "ams = threshold_tools.get_block_maxima(subsetted_data, extremes_type='max', check_ess=False)\n",
+    "ams = ck.load(ams, progress_bar=True) \n",
     "ams"
    ]
   },
@@ -283,6 +282,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9f7af1ed-2a85-46cd-b301-b83de0fe6c84",
+   "metadata": {},
+   "source": [
+    "**Note:** The following cell takes ~20 minutes to run!"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "4c0cd847-1a20-4abc-a1b8-a84e7e1debe1",
@@ -291,6 +298,7 @@
    },
    "outputs": [],
    "source": [
+    "%%time\n",
     "return_value = threshold_tools.get_return_value(\n",
     "    ams, return_period=10, distr='gev',\n",
     "    bootstrap_runs=100,\n",
@@ -324,6 +332,7 @@
    },
    "outputs": [],
    "source": [
+    "%%time\n",
     "return_prob = threshold_tools.get_return_prob(ams, threshold=300, distr='pearson3', multiple_points=True)\n",
     "return_prob"
    ]
@@ -351,6 +360,7 @@
    },
    "outputs": [],
    "source": [
+    "%%time\n",
     "return_period = threshold_tools.get_return_period(ams, return_value=300, distr='weibull', multiple_points=True)\n",
     "return_period"
    ]


### PR DESCRIPTION
Notebook originally taking ~25 hrs because of spatial extent not being constrained (may have been unconstrained due to some merge conflict). Spatial extent is limited to California, to 45 km, with more visibility into runtimes to result in a total notebook runtime of ~50-55 min.