### PR TITLE
Enable internal variability analyses based on 1.5 and 2.0 C warming

### DIFF
--- a/exploratory/internal_variability.ipynb
+++ b/exploratory/internal_variability.ipynb
@@ -462,7 +462,8 @@
    "outputs": [],
    "source": [
     "hist_cae_ds, warm_cae_ds = get_ensemble_data(\n",
-    "    variable=copt.variable, selections=selections, cmip_names=cmip_names\n",
+    "    variable=copt.variable, selections=selections, \n",
+    "    cmip_names=cmip_names, warm_level=warm_level\n",
     ")"
    ]
   },

--- a/exploratory/internal_variability.ipynb
+++ b/exploratory/internal_variability.ipynb
@@ -78,6 +78,8 @@
    "source": [
     "import climakitae as ck\n",
     "from climakitae.core.data_interface import DataParameters\n",
+    "import panel as pn\n",
+    "pn.extension()\n",
     "from climakitae.explore.uncertainty import (\n",
     "    CmipOpt, get_ensemble_data,\n",
     "    get_warm_level, grab_multimodel_data,\n",
@@ -1267,14 +1269,6 @@
     "\n",
     "Want to know more about model uncertainty? Check out the [model_uncertainty.ipynb](model_uncertainty.ipynb) notebook too!"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c9c2b6a-2997-477a-8811-6bacb3ce63d1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/exploratory/internal_variability.ipynb
+++ b/exploratory/internal_variability.ipynb
@@ -167,7 +167,7 @@
    "id": "fcbbf656-f49f-4a55-ba2c-1657548c38b7",
    "metadata": {},
    "source": [
-    "Specify the warming threshold in deg C. You don't have to change anything, but feel free to specify any of the following: `1.5, 2.0, 3.0, 4.0`."
+    "Specify the warming threshold in deg C. You don't have to change anything, but feel free to specify any of the following: `1.5, 2.0, 3.0`."
    ]
   },
   {

--- a/exploratory/internal_variability.ipynb
+++ b/exploratory/internal_variability.ipynb
@@ -77,9 +77,7 @@
    "outputs": [],
    "source": [
     "import climakitae as ck\n",
-    "import climakitaegui as ckg\n",
-    "import panel as pn\n",
-    "pn.extension()\n",
+    "from climakitae.core.data_interface import DataParameters\n",
     "from climakitae.explore.uncertainty import (\n",
     "    CmipOpt, get_ensemble_data,\n",
     "    get_warm_level, grab_multimodel_data,\n",
@@ -110,22 +108,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a5dcdfe",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "selections = ckg.Select()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "cca191af-ce6e-4f77-b1e6-c8fc189c9014",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
+    "selections = DataParameters()\n",
     "selections.area_average = 'No'\n",
     "selections.area_subset = 'states'\n",
     "selections.cached_area = ['CA']\n",
@@ -174,7 +163,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eb4a30bf-e17b-4a94-822c-6703aa0dfec7",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "warm_level = 3.0"
@@ -239,7 +230,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c6a86c4b-199f-4e27-9467-b36097e02e11",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "## define a plotting function\n",
@@ -432,7 +425,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3efbf741-92bc-4634-900b-c6671e2a6cec",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# select data options\n",
@@ -479,7 +474,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "16e10ef0-1bba-41d6-a617-9eb4af510d44",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Compute the 99th percentile \n",
@@ -505,7 +502,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "36d2ac31-ae62-47fd-8fe2-0de2f535ac12",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Plotting helper functions\n",
@@ -553,7 +552,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "db16eeb1-0866-48fe-9788-9982cac07f5b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "all_hist_ens = hvplot_percentile_column(\n",
@@ -614,7 +615,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "96160b74-abd5-47e2-97fe-da1c1b2a7a20",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "mdls_ds = grab_multimodel_data(copt,alpha_sort=True)\n",
@@ -676,7 +679,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "177a3cd3-a380-4ee9-8bf1-3630119a5950",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "vmin = 0\n",
@@ -899,7 +904,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6bedd466-e867-46d0-9a17-20ffbe7b010e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# first for the downscaled results\n",
@@ -1021,7 +1028,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "16e3b462-3eae-4b42-a592-beb6b24eb8f0",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "selections.area_subset='states'\n",
@@ -1039,7 +1048,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dbed3ea6-b9d2-40b2-ad21-68f3f7587772",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "box_hist_wrf = box_wrf_ds.sel(\n",
@@ -1074,7 +1085,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ce7a9586-7590-4c22-947e-3d7d160ab50f",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hist_wrf_pool = box_hist_wrf.stack(index=['simulation','time'])\n",
@@ -1104,7 +1117,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f6f6ecb9-98f5-4cc8-be8b-673e3d27556e",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "hist_wrf_pool_perc = hist_wrf_pool.chunk(\n",
@@ -1140,7 +1155,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "28dfeb20-d40a-4895-9777-6e742489f58b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "vmin = 0\n",
@@ -1216,7 +1233,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1969c1c5-ead1-4fae-ab7c-e8f6e4815c6b",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "pool_cads_tabs"
@@ -1248,6 +1267,14 @@
     "\n",
     "Want to know more about model uncertainty? Check out the [model_uncertainty.ipynb](model_uncertainty.ipynb) notebook too!"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c9c2b6a-2997-477a-8811-6bacb3ce63d1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/exploratory/internal_variability.ipynb
+++ b/exploratory/internal_variability.ipynb
@@ -983,6 +983,7 @@
     "             + \" precipitation accumulation, subregion average\")\n",
     "ax.set_ylabel(\"% change\", fontsize=14)\n",
     "ax.set_xlabel(\"Model\", fontsize=14)\n",
+    "plt.xticks(rotation=20)\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
## Summary of changes and related issue
In `internal_variability.ipynb`:
- Retrieve warming level data in cell 9 based on `warm_level` specified in cell 4
- Fix overlapping text on figures output from analyses of 1.5 and 2.0 C data
- Remove 4.0 option

## Relevant motivation and context
User options for `warm_level` (cell 4) are 1.5, 2.0, 3.0, and 4.0 C, but 3.0 C data are retrieved in cell 9 regardless of the choice. Also, only one model has 4.0 data for analyses.

## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [ ] Markdown reviewed and vetted by someone else
- [ ] Error messages for areas that might expect common user error
- [ ] Verbose and non-verbose modes function
- [ ] It may not be required for notebooks that explicitly don’t need this functionality
- [ ] List notebook overall runtime text
- [ ] Clear expectations of outcomes learned (key takeaway messages) provided