### PR TITLE
Enable internal variability analyses based on 0.8 and 1.2 C warming

### DIFF
--- a/exploratory/internal_variability.ipynb
+++ b/exploratory/internal_variability.ipynb
@@ -158,7 +158,7 @@
    "id": "fcbbf656-f49f-4a55-ba2c-1657548c38b7",
    "metadata": {},
    "source": [
-    "Specify the warming threshold in deg C. You don't have to change anything, but feel free to specify any of the following: `1.5, 2.0, 3.0`."
+    "Specify the warming threshold in deg C. You don't have to change anything, but feel free to specify any of the following: `0.8, 1.2, 1.5, 2.0, 3.0`."
    ]
   },
   {


### PR DESCRIPTION
## Summary of changes and related issue
- TODO
    - Update backend in https://github.com/cal-adapt/climakitae/pull/470
    - In cell 4, specify `warm_level` as 0.8 or 1.2, and review the notebook

## Relevant motivation and context
Current options are future facing at 1.5, 2, and 3 C. Present-day options may augment the analyses. 

## Type of Change

- [ ] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [ ] Markdown reviewed and vetted by someone else
- [ ] Error messages for areas that might expect common user error
- [ ] Verbose and non-verbose modes function
- [ ] It may not be required for notebooks that explicitly don’t need this functionality
- [ ] List notebook overall runtime text
- [ ] Clear expectations of outcomes learned (key takeaway messages) provided