### PR TITLE
update SSP spacing, remove inactive lat/lon import cell

### DIFF
--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -40,20 +40,7 @@
     "tags": []
    },
    "source": [
-    "### Step 1: Import locations\n",
-    "Now we'll read in point-based locations that we want to retrieve data for. For custom inputs, there are two options: (1) Input a single pair of latitude - longitude values; and (2) Import a csv file of locations that will each run. In the code below we show what each option looks like. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f86bed4b-a58d-4d9b-9a06-adfb5fb89717",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## select a single custom location\n",
-    "# your_lat = LAT\n",
-    "# your_lon = LON"
+    "### Step 1: Import locations"
    ]
   },
   {
@@ -109,7 +96,7 @@
     "|time_start_year | Numerical (min is 1981) | Required for **approach=Time** | |\n",
     "|time_end_year | Numerical (max is 2100) | Required for **approach=Time**| |\n",
     "|historical_data| \"Historical Climate\", \"Historical Reconstruction\" | Required for **approach=Time**| **Historical Climate** ranges from 1980-2015 for WRF and 1950-2015 for LOCA2-Hybrid. **Historical Reconstruction** ranges from 1950-2022. Historical Reconstruction data cannot be combined with SSP data.|\n",
-    "|ssp_data | \"[SSP2-4.5]\", \"[SSP3-7.0]\", \"[SSP5-8.5]\" | Required for **approach=Time** | Dynamical only has SSP3-7.0, Statisical has all 3 SSP options|\n",
+    "|ssp_data | \"[SSP 2-4.5]\", \"[SSP 3-7.0]\", \"[SSP 5-8.5]\" | Required for **approach=Time** | Dynamical only has SSP 3-7.0, Statisical has all 3 SSP options|\n",
     "|warming_level| 1.5, 2.0, 2.5, 3.0 | Required for **approach=Warming Level**| |\n",
     "|metric_calc| \"max\", \"min\" | Required for 1-in-X events, Heat Index, likely seasonal event | |\n",
     "|heat_idx_threshold | Numerical | Required for Heat Index | Heat Index can only be calculated with **downscaling_method=\"Dynamical\"**|\n",
@@ -170,7 +157,7 @@
     "    time_start_year=2030, \n",
     "    time_end_year=2050,\n",
     "    downscaling_method=\"Dynamical\",  # WRF data\n",
-    "    ssp_data=[\"SSP3-7.0\"],\n",
+    "    ssp_data=[\"SSP 3-7.0\"],\n",
     "    wrf_bias_adjust=False, # return all WRF models\n",
     "    \n",
     "    ## Likely seaonal event specific arguments\n",
@@ -212,7 +199,7 @@
     "    time_end_year=2050,\n",
     "    downscaling_method=\"Dynamical\",  # WRF data\n",
     "    approach=\"Time\",  \n",
-    "    ssp_data=[\"SSP3-7.0\"],\n",
+    "    ssp_data=[\"SSP 3-7.0\"],\n",
     "    wrf_bias_adjust=False, # return all WRF models\n",
     "    \n",
     "    ## Likely seaonal event specific arguments\n",
@@ -254,7 +241,7 @@
     "    time_end_year=2090,\n",
     "    downscaling_method=\"Dynamical\",  # WRF data \n",
     "    approach=\"Time\",  \n",
-    "    ssp_data=[\"SSP3-7.0\"],\n",
+    "    ssp_data=[\"SSP 3-7.0\"],\n",
     "    wrf_bias_adjust=True, # return bias adjusted WRF models\n",
     "    \n",
     "    ## 1-in-X event specific arguments\n",
@@ -295,7 +282,7 @@
     "    time_end_year=2060,\n",
     "    downscaling_method=\"Dynamical\",  # WRF data\n",
     "    approach=\"Time\",  \n",
-    "    ssp_data=[\"SSP3-7.0\"],\n",
+    "    ssp_data=[\"SSP 3-7.0\"],\n",
     "    \n",
     "    ## Heat Index specific arguments\n",
     "    variable=\"NOAA Heat Index\", \n",
@@ -472,7 +459,7 @@
    "metadata": {},
    "source": [
     "#### Example: 1-in-X precipitation event\n",
-    "Example scenario: I want to calculate \"1-in-10 year precipitation event using the GEV distribution, in inches, for 2070-2090 with SSP3-7.0, using LOCA2 data, and export both the raw and calculated metric data.\" I would input:\n",
+    "Example scenario: I want to calculate \"1-in-10 year precipitation event using the GEV distribution, in inches, for 2070-2090 with SSP 3-7.0, using LOCA2 data, and export both the raw and calculated metric data.\" I would input:\n",
     "\n",
     "**Notes**: \n",
     "- For daily precipitation 1-in-X events (i.e., 24-hour), we recommend the use of LOCA2 data instead of WRF data. If looking for a non-24-hour event, WRF data must be used, as the LOCA2 data is not available at hourly time steps. \n",
@@ -496,7 +483,7 @@
     "    time_end_year=2090,\n",
     "    downscaling_method=\"Statistical\",  # LOCA2 data \n",
     "    approach=\"Time\",  \n",
-    "    ssp_data=[\"SSP3-7.0\"], # ssp selection\n",
+    "    ssp_data=[\"SSP 3-7.0\"], # ssp selection\n",
     "    \n",
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Precipitation (total)\",\n",


### PR DESCRIPTION
## Summary of changes and related issue
Context: https://github.com/cal-adapt/climakitae/pull/477

## Relevant motivation and context
Missing SSP import in backend code, needed to update examples for new spacing. 

## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Markdown reviewed and vetted by someone else
- [x] Error messages for areas that might expect common user error
- [x] Verbose and non-verbose modes function
- [x] It may not be required for notebooks that explicitly don’t need this functionality
- [x] List notebook overall runtime text
- [x] Clear expectations of outcomes learned (key takeaway messages) provided