### PR TITLE
Renames annual consumption model nb to degree days

### DIFF
--- a/AE_navigation_guide.ipynb
+++ b/AE_navigation_guide.ipynb
@@ -65,7 +65,7 @@
     "### Collaborative Notebooks\n",
     "-------------------------------------\n",
     "#### Demand Forecast Unit\n",
-    "[annual_consumption_model.ipynb](collaborative/DFU/annual_consumption_model.ipynb): Perform calculations and explore visualizations of generated weather and climate information for an annual consumption model by producing heating and cooling degree days.<br>*For example: How will heating degree days in Sacramento change by mid-century?*\n",
+    "[degree_days.ipynb](collaborative/DFU/degree_days.ipynb): Perform calculations and explore visualizations of generated weather and climate information for an annual consumption model by producing heating and cooling degree days.<br>*For example: How will the number of heating degree days above 70°F in Sacramento change by mid-century?*\n",
     "\n",
     "[localization_methodology.ipynb](collaborative/DFU/localization_methodology.ipynb): Introduction to the localization method for examining climate projections at a location.<br>*For example: How does localization of global climate models to a weather station work?*\n",
     "\n",

--- a/collaborative/DFU/degree_days.ipynb
+++ b/collaborative/DFU/degree_days.ipynb
@@ -5,7 +5,7 @@
    "id": "fc908fc1-557b-49ad-b515-70e91ed630c8",
    "metadata": {},
    "source": [
-    "# Using the Analytics Engine (AE) to reproduce annual consumption model\n",
+    "# Using the Analytics Engine (AE) to produce heating and cooling degree days\n",
     "This notebook aims to reproduce the workflow CEC's Demand Forecast Unit takes to generate weather and climate information for the annual consumption model. Here the existing workflow is replicated, but connecting with new data from California's Fifth Climate Change Assessment.\n",
     "\n",
     "To execute a given 'cell' of this notebook, place the cursor in the cell and press the 'play' icon, or simply press shift+enter together. Some cells will take longer to run, and you will see a [$\\ast$] to the left of the cell while AE is still working.\n",
@@ -62,15 +62,13 @@
    },
    "outputs": [],
    "source": [
+    "import climakitae as ck\n",
+    "import climakitaegui as ckg\n",
+    "from climakitae.core.data_interface import get_data\n",
     "from climakitae.util.utils import (convert_to_local_time, compute_annual_aggreggate, trendline, \n",
     "                                   compute_multimodel_stats, combine_hdd_cdd)\n",
     "from climakitae.tools.derived_variables import compute_hdd_cdd, compute_hdh_cdh\n",
-    "from climakitaegui.util.utils import (hdd_cdd_lineplot, hdh_cdh_lineplot)\n",
-    "\n",
-    "import climakitae as ck\n",
-    "import climakitaegui as ckg\n",
-    "import panel as pn\n",
-    "pn.extension()"
+    "from climakitaegui.util.utils import (hdd_cdd_lineplot, hdh_cdh_lineplot)"
    ]
   },
   {
@@ -107,7 +105,7 @@
     "selections.cached_area = [\"SMUD Service Territory\"]\n",
     "selections.historical_scenario = \"Historical Climate\"\n",
     "selections.scenario_ssp = [\"SSP 3-7.0\"]\n",
-    "selections.time_slice = (2005,2025)\n",
+    "selections.time_slice = (2005, 2025)\n",
     "selections.timescale = \"hourly\"\n",
     "selections.resolution = \"3 km\"\n",
     "selections.units = \"degF\"\n",
@@ -140,7 +138,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4ceda482-9303-4f98-ade3-65f164e40560",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "data_at_station = convert_to_local_time(data_at_station, selections)"
@@ -164,7 +164,8 @@
    },
    "outputs": [],
    "source": [
-    "data_at_station = ck.load(data_at_station)"
+    "data_at_station = ck.load(data_at_station)\n",
+    "data_at_station"
    ]
   },
   {
@@ -250,22 +251,15 @@
    "source": [
     "## Step 2: Get data from across the demand forecast zone\n",
     "\n",
-    "As an alternative to a single point, we can instead consider weather conditions across an entire forecast zone. In this example, we calculate the median of all conditions across the Sacramento Municipal Utility District.\n",
-    "\n",
-    "### 2a) Select the data\n",
-    "\n",
-    "Using `Select()` we have pre-loaded data selections for gridded air temperature within the Sacramento Municipal Utility District for 2005-2025. However, if you would like to make modifications, or see how the data can be selected, run `selections.show()` in a cell below to pull up a useful panel that illustrates all of the data options. \n",
-    "\n",
-    "Reminder: The gridded data we will be retrieving in this step and using throughout this notebook is not bias-corrected."
+    "As an alternative to a single point, we can instead consider weather conditions across an entire forecast zone. In this example, we calculate the median of all conditions across the Sacramento Municipal Utility District. We have pre-loaded data selections for gridded air temperature within the Sacramento Municipal Utility District for 2005-2025. Feel free to make modifications for your own workflows. <br>\n",
+    "**Reminder**: The gridded data we will be retrieving in this step and using throughout this notebook is not bias-corrected."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7a0c21a-6218-444e-91ab-795c8012b8fe",
-   "metadata": {
-    "tags": []
-   },
+   "id": "35e84f21-69df-48e4-9b10-c07236b582e5",
+   "metadata": {},
    "outputs": [],
    "source": [
     "selections.data_type = \"Gridded\"\n",
@@ -276,18 +270,8 @@
     "selections.time_slice = (2005,2025)\n",
     "selections.timescale = \"hourly\"\n",
     "selections.resolution = \"9 km\"\n",
-    "selections.units = \"degF\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4a31146f-d883-4b5d-9357-65bef6a93549",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "selections.units = \"degF\"\n",
+    "\n",
     "data_dfz = selections.retrieve()"
    ]
   },
@@ -295,33 +279,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b681a024-b44f-4e25-a579-ab7a8826ab81",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_dfz = convert_to_local_time(data_dfz, selections)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f534281e-54ff-4764-8080-090fb44d700f",
-   "metadata": {},
-   "source": [
-    "### 2b) Load the data into memory\n",
-    "\n",
-    "This may take some time, because the gridded data has to be loaded into memory. All computations we've done before this step are actually computed in this step; before, we just see a preview of the data. Because of this, **we recommend running this notebook in the Analytics Engine's Jupyter Hub, which provides additional computational resources that greatly speed up this step.**"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "273d3440-d7a2-44c0-b3d0-f8ebfe4b0da9",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "%%time\n",
-    "data_dfz = ck.load(data_dfz)"
+    "data_dfz = convert_to_local_time(data_dfz, selections)"
    ]
   },
   {
@@ -555,7 +518,7 @@
    },
    "outputs": [],
    "source": [
-    "hdd, cdd = compute_hdd_cdd(data_to_use, hdd_threshold=60, cdd_threshold=70) # Set for all data within selected DFZ zone"
+    "hdd, cdd = compute_hdd_cdd(data_to_use, hdd_threshold=65, cdd_threshold=65) # Set for all data within selected DFZ zone"
    ]
   },
   {


### PR DESCRIPTION
## Summary of changes and related issue
- Renames the notebook to be `degree_days.ipynb`
- Updates the `AE_navigation_guide.ipynb` for notebook name and example question notebook can address
- Minor markdown changes

**Note**:
- This notebook currently breaks on the `convert_to_local_time` function for station-based data and is being updated by @nicolejkeeney. 
- This notebook currently uses the "old" way of data retrieval. The gridded data retrieval can be updated to the new `get_data` method, however the station-based data cannot via `get_data`. To avoid a mix of data retrieval methods within the notebook, keeping as the older retrieval method until `get_data` has station based data as an option. 

## Relevant motivation and context
Following request by IOU and IEPR reports, heating and cooling degree days are increasingly important; however the notebook itself is hard to find because the name is not intuitive. 

## Type of Change
- [ ] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [x] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
