### PR TITLE
Zarr export changes to getting_started notebook

### DIFF
--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -225,9 +225,11 @@
     "To save data as a file, call `export` and input your desired\n",
     "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
     "2) output file name (without file extension)\n",
-    "3) file format (\"NetCDF\" or \"CSV\")\n",
+    "3) file format (\"NetCDF\", \"Zarr\", or \"CSV\")\n",
     "\n",
-    "We recommend NetCDF, which suits data and outputs from the Analytics Engine well – it efficiently stores large data containing multiple variables and dimensions. Metadata will be retained in NetCDF files.\n",
+    "We recommend NetCDF or Zarr, which suits data and outputs from the Analytics Engine well – they efficiently store large data containing multiple variables and dimensions. Metadata will be retained in these files.\n",
+    "\n",
+    "NetCDF or Zarr can be export locally (such as onto the JupyterHUB user partition). Optionally Zarr can be exported to an AWS S3 scratch bucket for storing very large exports.\n",
     "\n",
     "CSV can also store Analytics Engine data with any number of variables and dimensions. It works the best for smaller data with fewer dimensions. The output file will be compressed to ensure efficient storage. Metadata will be preserved in a separate file.\n",
     "\n",
@@ -243,7 +245,37 @@
    },
    "outputs": [],
    "source": [
-    "ck.export(data_to_use, \"my_filename2\", \"NetCDF\")"
+    "ck.export(data_to_use, filename=\"my_filename1\", format=\"NetCDF\") # NetCDF4 export locally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bde1a569",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ck.export(data_to_use, filename=\"my_filename2\", format=\"Zarr\") # Zarr export locally"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06e6c9bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ck.export(data_to_use, filename=\"my_filename3\", format=\"Zarr\", mode=\"s3\") # Zarr export to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2da81ba8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ck.export(data_to_use, filename=\"my_filename4\", format=\"CSV\") # CSV export locally"
    ]
   }
  ],

--- a/getting_started.ipynb
+++ b/getting_started.ipynb
@@ -255,7 +255,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ck.export(data_to_use, filename=\"my_filename2\", format=\"Zarr\") # Zarr export locally"
+    "ck.export(data_to_use, filename=\"my_filename2\", format=\"Zarr\") # Zarr export locally\n",
+    "#ck.remove_zarr(\"my_filename2\") # helper function to delete Zarr directory tree"
    ]
   },
   {


### PR DESCRIPTION
## Summary of changes and related issue

Add new language to `getting_started` for exporting to Zarr and for removing Zarrs.

## Relevant motivation and context

Export functions in `climakitae` are changing so updating nb to reflect those changes.

## Type of Change

- [ ] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ x ] Documentation update
- [ ] None of the above

## Checklist
- [ ] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [ ] Notebook raises appropriate error messages for common user errors
- [ ] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
