### PR TITLE
Vul Assess notebook changes to reflect back-end updates

### DIFF
--- a/collaborative/IOU/vulnerability_assessment/README.md
+++ b/collaborative/IOU/vulnerability_assessment/README.md
@@ -108,8 +108,8 @@ Order of operations:
 
 Warming Level Options
 =====================
-**Historical Reference Periods**: 0.8°C, 1.0°C, 1.2°C
-**Future GWL Periods**: 1.5°C, 2.0°C, 2.5°C, 3.0°C
+**Historical Reference Periods**: 0.8°C, 1.0°C, 1.2°C<br>
+**Future GWL Periods**: 1.5°C, 2.0°C, 2.5°C, 3.0°C<br>
 
 Notes:
 1. Global warming levels are calculated *per climate model* relative to pre-industrial conditions (1850-1900).

--- a/collaborative/IOU/vulnerability_assessment/README.md
+++ b/collaborative/IOU/vulnerability_assessment/README.md
@@ -8,10 +8,9 @@ For more detailed code, please see these computational scripts:
 <br> [Warming](https://github.com/cal-adapt/climakitae/blob/main/climakitae/explore.warming.py)
 
 This document is *in progress* and will update frequently as additional details are added. 
-
-v1 - September 2024, methods
-
-v2 - October 2024, data size limitations 
+- v1 - September 2024, methods
+- v2 - October 2024, data size limitations
+- v3 - March 2025, Additional GWL context
 
 Methodology
 ===========
@@ -20,7 +19,7 @@ Methodology
 Example: 1-in-10 year maximum temperature
 
 Arguments:
-    <br>**one_in_x**: The return period ("X") is determined by the "one_in_x" argument, where "x" is the desired return period, and is required user input. Options are numerical.
+    <br>**one_in_x**: The return period ("X") is determined by the "one_in_x" argument, where "x" is the desired return period, and is required user input. Options are numerical, or a list of options.
     <br>**metric_calc**: Max/min denotes whether the daily minimum or maximum is desired (daytime high vs. nighttime low), where "metric_calc" is a required user input. Options are "min" and "max".
     <br>**distr**: The goodness of fit distribution, and is an optional user input. Default is set to the generalized extreme value ("gev" distribution). Options are "gev", "gumbel", "weibull", "pearson3", "genpareto", "gamma". Please see the [threshold tools notebook](https://github.com/cal-adapt/cae-notebooks/blob/main/work_in_progress/threshold_basics.ipynb) for more information. 
 
@@ -29,6 +28,9 @@ Order of operations:
     <br>2. Annual maximum series is passed to the `get_return_value` thresholds tool function in climakitae, where the "one_in_x" argument is passed to the "return_period" parameter. 
     <br>3. Return periods per simulation are concatenanted back into a single data object.
     <br>4. Data is returned.
+
+Notes:
+    <br>1. You may pass multiple return periods to **one_in_x** to generate multiple events, e.g., `one_in_x = [10, 100]` or `one_in_x = 10`.
 
 
 Likely seasonal events
@@ -69,7 +71,7 @@ Note: Heat Index can only be calculated with dynamically-downscaled data (WRF) d
 Example: 1-in-100 year, 24-hour precipitation; 1-in-10 year, 3-hour precipitation
 
 Arguments:
-    <br>**one_in_x**: The return period ("X") is determined by the "one_in_x" argument, where "x" is the desired return period, and is required user input. Options are numerical.
+    <br>**one_in_x**: The return period ("X") is determined by the "one_in_x" argument, where "x" is the desired return period, and is required user input. Options are numerical, or a list of options.
     <br>**metric_calc** Max/min denotes whether the daily minimum or maximum is desired (daytime high vs. nighttime low), where "metric_calc" is a required user input. Options are "min" and "max".
     <br>**distr**: The goodness of fit distribution, and is an optional user input. Default is set to the generalized extreme value ("gev" distribution). Options are "gev", "gumbel", "weibull", "pearson3", "genpareto", "gamma". Please see the [threshold tools notebook](https://github.com/cal-adapt/cae-notebooks/blob/main/work_in_progress/threshold_basics.ipynb) for more information. 
     <br>**event_freq**: The duration of event, and is an optional user input. Default is set to (1, "day") for a 24-hour event. Options are numerical for the event length (first item in tuple), and "day" or "hour" for the temporal frequency (second item in tuple). Example of an alternative event duration would be: (72, "hour"). 
@@ -86,6 +88,8 @@ Note:
     <br>2. The goodness of fit on the distribution is provided for 1-in-X precipitation events. The p-value of the distribution fit to the data is provided during the calculation step and as an attribute in the final data object. For 1-in-X precipitation events, **we recommend the use of "gev" as the distribution** for the first distribution test. GEV allows for a continuous range of different shapes, and will reduce to either Gumbel, Weibull, or Generalized Pareto distributions under different conditions. GEV is typically a better fit than the 3 individaul distributions, and is a common distribution in hydrological applications. If the **p-value is less than 0.05**, this indicates that the selected distribution is **not a good fit for the data**, and we recommend choosing a different distribution and re-running the cava_data function.
     <br>3. In certain geographic regions, the selection of a high return period event (e.g., 1-in-1000) may produce unrealistically high precipitation values. This is a limitation of the data sample size beyond what the data can reasonably estimate, where a small change in noise will produce a large change in the distribution tails.
     <br>4. In arid / desert geographic regions, some years may produce a negligble (approximately 0) precipitation amount for the block maxima series calculation necessary to calculate a 1-in-X event. The 1-in-X calculation has a check in place, that if a value of 0 or a nan occurs, the value is dropped so the remaining calculation does not fail. The check is applied for all variables, but essential for precipitation in arid climes.   
+    <br>5. You may pass multiple return periods to **one_in_x** to generate multiple events, e.g., `one_in_x = [10, 100]` or `one_in_x = 10`.
+
 
 Warming Levels
 ---------------
@@ -100,6 +104,16 @@ Order of operations:
     <br>2. Warming levels data is a 30-year window centered around the year that each individual simulation exceeds the designated warming level, based on the "warming_level" argument. The 30-year window is (center_year - 15 years, center_year, center_year + 14 years).
     <br>3. A synthetic "time" dimension is added back to the data object in order to calculate metrics (which typically need "time" as a dimension to resample). 
     <br>4. Data is passed to the requested metric. 
+
+
+Warming Level Options
+=====================
+**Historical Reference Periods**: 0.8°C, 1.0°C, 1.2°C
+**Future GWL Periods**: 1.5°C, 2.0°C, 2.5°C, 3.0°C
+
+Notes:
+1. Global warming levels are calculated *per climate model* relative to pre-industrial conditions (1850-1900).
+2. For more information, please see: [GWL Methods Guidance](https://analytics.cal-adapt.org/analytics/methods/).
 
 
 Recommended batch size limits

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Vulnerability Assessment Pilot\n",
-    "This notebook demonstrates on-going development of climate adaptation vulnerability assessment (CAVA) support using climate data in the Analytics Engine. \n",
+    "This notebook demonstrates on-going development of a vulnerability assessment support tool using climate data in the Analytics Engine. \n",
     "\n",
     "To execute a given 'cell' of this notebook, place the cursor in the cell and press the 'play' icon, or simply press shift+enter together. Some cells will take longer to run, and you will see a [$\\ast$] to the left of the cell while AE is still working.\n",
     "\n",
@@ -88,7 +88,7 @@
     "Below is a table outlining all avaialble arguments to the `cava_data` function. The \"Required\" flag notes whether the argument must be passed to start generating data. Input options for each argument is provided, as well as whether a setting is required for any of the required selections. We provide multiple examples of working with the `cava_data` function with multiple configurations.\n",
     "\n",
     "| Argument | Options | Argument required for | Notes |\n",
-    "|----------|---------|-----------------------|-------|\n",
+    "|----------|---------|-----------------------|------|\n",
     "|input_locations | Pass a location via csv. | All | Option to run either a single location, or multiple when **batch_mode=True**.|\n",
     "|variable | \"Air Temperature at 2m\", \"NOAA Heat Index\", \"Precipitation (total)\"| All | |\n",
     "|approach | \"Time\", \"Warming Level\" | All | |\n",
@@ -97,10 +97,10 @@
     "|time_end_year | Numerical (max is 2100) | Required for **approach=Time**.| |\n",
     "|historical_data| \"Historical Climate\", \"Historical Reconstruction\" | Required for **approach=Time**| **Historical Climate** ranges from 1980-2015 for WRF and 1950-2015 for LOCA2-Hybrid. **Historical Reconstruction** ranges from 1950-2022. Historical Reconstruction data cannot be combined with SSP data.|\n",
     "|ssp_data | \"[SSP 2-4.5]\", \"[SSP 3-7.0]\", \"[SSP 5-8.5]\" | Required for **approach=Time** | Dynamical only has SSP 3-7.0, Statisical has all 3 SSP options.|\n",
-    "|warming_level| 0.8, 1.2, 1.5, 2.0, 2.5, 3.0 | Required for **approach=Warming Level**| Historical/Current period GWLs: 0.8, 1.2. Future GWLs: 1.5, 2.0, 2.5, 3.0. |\n",
+    "|warming_level| 0.8, 1.0, 1.2, 1.5, 2.0, 2.5, 3.0 | Required for **approach=Warming Level**| Historical/Current period GWLs: 0.8, 1.0, 1.2. Future GWLs: 1.5, 2.0, 2.5, 3.0. |\n",
     "|metric_calc| \"max\", \"min\" | Required for 1-in-X events, Heat Index, likely seasonal event | |\n",
     "|heat_idx_threshold | Numerical | Required for Heat Index | Heat Index can only be calculated with **downscaling_method=\"Dynamical\"**.|\n",
-    "|one_in_x | List or Numerical values | Required for 1-in-X events| |\n",
+    "|one_in_x | List or Numerical values | Required for 1-in-X events| Example: one_in_x = 10 *or* one_in_x = [10, 100]|\n",
     "|event_duration| Numerical + \"day\"/\"hour\"| Optional for 1-in-X events| Must adhere to following structure: ({number}, \"{temporal frequency}\"). Temporal frequency options: \"day\", \"hour\". Default is (1, \"day\").|\n",
     "|distr| \"gev\", \"genpareto\", \"gumbel\", \"wibull\", \"pearson3\", \"gamma\"| Optional for 1-in-X events |Default set to \"gev\".|\n",
     "|percentile | Numerical (0-100) | Required for likely seasonal event |   |\n",
@@ -118,10 +118,10 @@
    "id": "a1718991-771d-4f53-873c-3a774644b772",
    "metadata": {},
    "source": [
-    "The following cells illustrate several examples of how to retrieve and calculate various configurations of the `cava_data` function. Below is a list of the examples; and more are coming soon as more functionality is built in!\n",
+    "The following cells illustrate several examples of how to retrieve and calculate various configurations of the `cava_data` function. Below is a list of the examples; and more are coming soon as more functionality is built in:\n",
     "1. Likely seasonal event, single location, time approach, all WRF data, with custom percentile\n",
     "2. Likely seasonal event, batch mode for multiple locations, time approach, all WRF data, with custom percentile\n",
-    "3. 1-in-X temperature event, single location, bias-adjusted WRF data only, time approach, with custom event frequency and distribution\n",
+    "3. 1-in-X temperature event, single location, bias-adjusted WRF data only, time approach, with custom return period, event frequency, and distribution\n",
     "4. Heat index event, single location, time approach, with custom threshold\n",
     "5. Likely seasonal event, single location, warming level approach, all WRF data, wtih custom percentile\n",
     "6. Likely seasonal event, single location, warming level approach, all LOCA2 data, with custom percentile\n",
@@ -129,7 +129,8 @@
     "8. Likely seasonal event, batch mode for multiple locations, warming levels approach, all LOCA2 data, with custom percentile\n",
     "9. 1-in-X precipitation event, single location, all LOCA2 data, time approach, with custom return period\n",
     "10. 1-in-X precipitation event, single location, all WRF data, time approach, with custom return period, event duration, and distribution\n",
-    "11. Example of reading the calculated metric data via xarray for easy viewing within this notebook. "
+    "11. Multiple 1-in-X temperature events, single location, bias-adjusted WRF data only, time approach, with custom return periods\n",
+    "12. Example of reading the calculated metric data via xarray for easy viewing within this notebook. "
    ]
   },
   {
@@ -220,7 +221,7 @@
    "metadata": {},
    "source": [
     "#### Example: 1-in-X temperature event\n",
-    "Example scenario: I want to calculate \"1-in-10 and 1-in-100 year maximum temperature using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
+    "Example scenario: I want to calculate \"1-in-10 year maximum temperature using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
    ]
   },
   {
@@ -242,14 +243,13 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Air Temperature at 2m\",\n",
     "    metric_calc=\"max\", # daily maximum temperature\n",
-    "    one_in_x=[10, 100], # One-in-X\n",
+    "    one_in_x=10, # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    units=\"degF\", # change units\n",
     "    \n",
     "    ## Export\n",
     "    export_method=\"both\",\n",
     "    file_format=\"NetCDF\",\n",
-    "    batch_mode=True,\n",
     ")"
    ]
   },
@@ -542,6 +542,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "be9cfd76-1faf-462b-8348-f28c01bd6ddd",
+   "metadata": {},
+   "source": [
+    "#### Example: Multiple 1-in-X temperature events\n",
+    "Example scenario: I want to calculate \"1-in-10 **and** 1-in-100 year maximum temperatures using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "306c005f-0c46-425b-b8c6-c183b3efe281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = cava_data(\n",
+    "    ## Set-up\n",
+    "    example_locs.iloc[:1], # select a single location\n",
+    "    time_start_year=2070,\n",
+    "    time_end_year=2090,\n",
+    "    downscaling_method=\"Dynamical\",  # WRF data \n",
+    "    approach=\"Time\",  \n",
+    "    wrf_bias_adjust=True, # return bias adjusted WRF models\n",
+    "    \n",
+    "    ## 1-in-X event specific arguments\n",
+    "    variable=\"Air Temperature at 2m\",\n",
+    "    metric_calc=\"max\", # daily maximum temperature\n",
+    "    one_in_x=[10, 100], # One-in-X\n",
+    "    distr=\"gev\", # change distribution\n",
+    "    units=\"degF\", # change units\n",
+    "    \n",
+    "    ## Export\n",
+    "    export_method=\"both\",\n",
+    "    file_format=\"NetCDF\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7d856628-522d-4375-926a-744fc9df86cb",
    "metadata": {},
    "source": [
@@ -584,7 +622,7 @@
    "id": "9c558433-b9c2-4b3a-b001-cce58c9067e0",
    "metadata": {},
    "source": [
-    "Below, you'll find code that generates a table with different climate data metrics used in a CAVA Report. Feel free to run it and check it out! It is still very much in progress. **This will take 30+ min. to run.**"
+    "Below, you'll find code that generates a table with different climate data metrics used in a vulnerability assessment. Feel free to run it and check it out! It is still very much in progress. **This will take 30+ min. to run.**"
    ]
   },
   {

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -29,6 +29,7 @@
    },
    "outputs": [],
    "source": [
+    "import numpy as np\n",
     "from climakitae.explore.vulnerability import cava_data\n",
     "from climakitae.explore.vulnerability_table import create_vul_table"
    ]
@@ -100,7 +101,7 @@
     "|warming_level| 0.8, 1.2, 1.5, 2.0, 2.5, 3.0 | Required for **approach=Warming Level**| Historical/Current period GWLs: 0.8, 1.2. Future GWLs: 1.5, 2.0, 2.5, 3.0. |\n",
     "|metric_calc| \"max\", \"min\" | Required for 1-in-X events, Heat Index, likely seasonal event | |\n",
     "|heat_idx_threshold | Numerical | Required for Heat Index | Heat Index can only be calculated with **downscaling_method=\"Dynamical\"**.|\n",
-    "|one_in_x | Numerical | Required for 1-in-X events| |\n",
+    "|one_in_x | np.array of Numerical x values | Required for 1-in-X events| |\n",
     "|event_duration| Numerical + \"day\"/\"hour\"| Optional for 1-in-X events| Must adhere to following structure: ({number}, \"{temporal frequency}\"). Temporal frequency options: \"day\", \"hour\". Default is (1, \"day\").|\n",
     "|distr| \"gev\", \"genpareto\", \"gumbel\", \"wibull\", \"pearson3\", \"gamma\"| Optional for 1-in-X events |Default set to \"gev\".|\n",
     "|percentile | Numerical (0-100) | Required for likely seasonal event |   |\n",
@@ -220,7 +221,7 @@
    "metadata": {},
    "source": [
     "#### Example: 1-in-X temperature event\n",
-    "Example scenario: I want to calculate \"1-in-10 year maximum temperature using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
+    "Example scenario: I want to calculate \"1-in-10 AND 1-in-100 year maximum temperature using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
    ]
   },
   {
@@ -244,9 +245,10 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Air Temperature at 2m\",\n",
     "    metric_calc=\"max\", # daily maximum temperature\n",
-    "    one_in_x=10, # One-in-X\n",
+    "    one_in_x=np.array([10]), # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    units=\"degF\", # change units\n",
+    "    batch_mode=True,\n",
     "    \n",
     "    ## Export\n",
     "    export_method=\"both\",\n",
@@ -485,7 +487,7 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Precipitation (total)\",\n",
     "    metric_calc=\"max\", # daily maximum precipitation\n",
-    "    one_in_x=10, # One-in-X\n",
+    "    one_in_x=np.array([10]), # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    units=\"inches\", # change units\n",
     "    \n",
@@ -530,7 +532,7 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Precipitation (total)\",\n",
     "    metric_calc=\"max\", # daily maximum precipitation\n",
-    "    one_in_x=100, # One-in-X\n",
+    "    one_in_x=np.array([100]), # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    event_duration = (3, 'hour'), # change event duration\n",
     "    units=\"inches\", # change units\n",
@@ -600,7 +602,7 @@
     "%%time\n",
     "percentile = 50\n",
     "heat_idx_threshold = 80\n",
-    "one_in_x = 10 # currently, only can do `one_in_x` for one value at a time\n",
+    "one_in_x = np.array([10])\n",
     "df = create_vul_table(example_locs.iloc[[10]], percentile, heat_idx_threshold, one_in_x)\n",
     "df"
    ]
@@ -622,7 +624,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -250,7 +250,6 @@
     "    export_method=\"both\",\n",
     "    file_format=\"NetCDF\",\n",
     "    batch_mode=True,\n",
-    "    separate_files=True\n",
     ")"
    ]
   },

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -29,7 +29,6 @@
    },
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "from climakitae.explore.vulnerability import cava_data\n",
     "from climakitae.explore.vulnerability_table import create_vul_table"
    ]
@@ -101,7 +100,7 @@
     "|warming_level| 0.8, 1.2, 1.5, 2.0, 2.5, 3.0 | Required for **approach=Warming Level**| Historical/Current period GWLs: 0.8, 1.2. Future GWLs: 1.5, 2.0, 2.5, 3.0. |\n",
     "|metric_calc| \"max\", \"min\" | Required for 1-in-X events, Heat Index, likely seasonal event | |\n",
     "|heat_idx_threshold | Numerical | Required for Heat Index | Heat Index can only be calculated with **downscaling_method=\"Dynamical\"**.|\n",
-    "|one_in_x | np.array of Numerical x values | Required for 1-in-X events| |\n",
+    "|one_in_x | List or Numerical values | Required for 1-in-X events| |\n",
     "|event_duration| Numerical + \"day\"/\"hour\"| Optional for 1-in-X events| Must adhere to following structure: ({number}, \"{temporal frequency}\"). Temporal frequency options: \"day\", \"hour\". Default is (1, \"day\").|\n",
     "|distr| \"gev\", \"genpareto\", \"gumbel\", \"wibull\", \"pearson3\", \"gamma\"| Optional for 1-in-X events |Default set to \"gev\".|\n",
     "|percentile | Numerical (0-100) | Required for likely seasonal event |   |\n",
@@ -221,16 +220,14 @@
    "metadata": {},
    "source": [
     "#### Example: 1-in-X temperature event\n",
-    "Example scenario: I want to calculate \"1-in-10 AND 1-in-100 year maximum temperature using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
+    "Example scenario: I want to calculate \"1-in-10 and 1-in-100 year maximum temperature using the GEV distribution, in Fahrenheit, for 2070-2090, using only the bias-adjusted WRF data, and export both the raw and calculated metric data.\" I would input:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1cb333d9-23db-44c1-a664-985f9e9a79be",
-   "metadata": {
-    "tags": []
-   },
+   "id": "23d69b0e-5bf1-48d5-b345-10eead6a7094",
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = cava_data(\n",
@@ -245,13 +242,15 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Air Temperature at 2m\",\n",
     "    metric_calc=\"max\", # daily maximum temperature\n",
-    "    one_in_x=np.array([10]), # One-in-X\n",
+    "    one_in_x=[10, 100], # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    units=\"degF\", # change units\n",
     "    \n",
     "    ## Export\n",
     "    export_method=\"both\",\n",
     "    file_format=\"NetCDF\",\n",
+    "    batch_mode=True,\n",
+    "    separate_files=True\n",
     ")"
    ]
   },
@@ -486,7 +485,7 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Precipitation (total)\",\n",
     "    metric_calc=\"max\", # daily maximum precipitation\n",
-    "    one_in_x=np.array([10]), # One-in-X\n",
+    "    one_in_x=10, # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    units=\"inches\", # change units\n",
     "    \n",
@@ -531,7 +530,7 @@
     "    ## 1-in-X event specific arguments\n",
     "    variable=\"Precipitation (total)\",\n",
     "    metric_calc=\"max\", # daily maximum precipitation\n",
-    "    one_in_x=np.array([100]), # One-in-X\n",
+    "    one_in_x=100, # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    event_duration = (3, 'hour'), # change event duration\n",
     "    units=\"inches\", # change units\n",
@@ -601,7 +600,7 @@
     "%%time\n",
     "percentile = 50\n",
     "heat_idx_threshold = 80\n",
-    "one_in_x = np.array([10])\n",
+    "one_in_x = 10 # currently, only can do `one_in_x` for one value at a time\n",
     "df = create_vul_table(example_locs.iloc[[10]], percentile, heat_idx_threshold, one_in_x)\n",
     "df"
    ]

--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -248,7 +248,6 @@
     "    one_in_x=np.array([10]), # One-in-X\n",
     "    distr=\"gev\", # change distribution\n",
     "    units=\"degF\", # change units\n",
-    "    batch_mode=True,\n",
     "    \n",
     "    ## Export\n",
     "    export_method=\"both\",\n",


### PR DESCRIPTION
## Summary of changes and related issue
Changing `vulnerability_assessment.ipynb` to reflect changes in back-end that allow multiple 1-in-X params to be passed in, but ONLY as `np.array`'s. 

Back-end changes: https://github.com/cal-adapt/climakitae/pull/518

## Relevant motivation and context
We want the notebook to be up to date with what's available in the AE back-end 

## Type of Change

- [ ] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [x] Documentation update
- [ ] None of the above

## Checklist
- [ ] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [ ] Notebook raises appropriate error messages for common user errors
- [ ] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
