### PR TITLE
Update navigation guide

### DIFF
--- a/AE_navigation_guide.ipynb
+++ b/AE_navigation_guide.ipynb
@@ -46,8 +46,6 @@
     "\n",
     "[model_uncertainty.ipynb](exploratory/model_uncertainty.ipynb): Explore uncertainty across climate models, using projected variations in air temperature trends across different climate model simulations.<br>*For example: When is it appropriate to take a mean across different global climate models?*\n",
     "\n",
-    "[climate_data_comparisons.ipynb](exploratory/climate_data_comparisons): Explore how to compare datasets across the historical period, using observations, reanalysis, and model output.<br>*For example: How do I compare historical precipitation between a weather station and climate model?*\n",
-    "\n",
     "[historical_climate_data_comparisons.ipynb](exploratory/historical_climate_data_comparisons.ipynb): Explore how to use different kinds of historical climate data available on the AE, including weather stations, reanalysis products, and model output.<br>*For example: What are the trade-offs of using climate model versus observational data products as a historical baseline?*\n",
     "\n",
     "### Tool Notebooks\n",

--- a/AE_navigation_guide.ipynb
+++ b/AE_navigation_guide.ipynb
@@ -102,7 +102,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "climakitae-tests",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -116,7 +116,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/AE_navigation_guide.ipynb
+++ b/AE_navigation_guide.ipynb
@@ -48,6 +48,8 @@
     "\n",
     "[climate_data_comparisons.ipynb](exploratory/climate_data_comparisons): Explore how to compare datasets across the historical period, using observations, reanalysis, and model output.<br>*For example: How do I compare historical precipitation between a weather station and climate model?*\n",
     "\n",
+    "[historical_climate_data_comparisons.ipynb](exploratory/historical_climate_data_comparisons.ipynb): Explore how to use different kinds of historical climate data available on the AE, including weather stations, reanalysis products, and model output.<br>*For example: What are the trade-offs of using climate model versus observational data products as a historical baseline?*\n",
+    "\n",
     "### Tool Notebooks\n",
     "---------------------------------\n",
     "#### Extreme Weather Events \n",
@@ -67,12 +69,18 @@
     "#### Demand Forecast Unit\n",
     "[degree_days.ipynb](collaborative/DFU/degree_days.ipynb): Perform calculations and explore visualizations of generated weather and climate information for an annual consumption model by producing heating and cooling degree days.<br>*For example: How will the number of heating degree days above 70°F in Sacramento change by mid-century?*\n",
     "\n",
+    "[download_localized_stations.ipynb](collaborative/DFU/download_localized_stations.ipynb): Download bias-corrected air temperature and dewpoint temperature model timeseries localized for any of 71 weather stations in the WECC.<br>*For example: What is the bias-corrected summer temperature timeseries at a single station?*\n",
+    "\n",
     "[localization_methodology.ipynb](collaborative/DFU/localization_methodology.ipynb): Introduction to the localization method for examining climate projections at a location.<br>*For example: How does localization of global climate models to a weather station work?*\n",
+    "\n",
+    "[station_data_access.ipynb](collaborative/DFU/station_data_access.ipynb): Demonstrates how to access historical meteorological station data for stations of interest in the WECC.<br>*For example: What is the historical mean surface air temperature at Sacramento Executive Airport (KSAC)?*\n",
     "\n",
     "[station_hourly_profiles.ipynb](collaborative/DFU/station_hourly_profiles.ipynb): Explore the process to produce hourly profiles of localized data.<br>*For example: What does the median hourly profile of 8760s look like for Los Angeles?*\n",
     "\n",
     "#### Investor-Owned Utilities\n",
     "[heat_index.ipynb](collaborative/IOU/heat_index.ipynb): Generate historical and projected trends of Heat Index at a location.<br>*For example: How many summer days will be above a heat index of 91°F in Fresno by mid-century?*\n",
+    "\n",
+    "[vulnerability_assessment.ipynb](collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb): Access climate projections data for a vulnerability assessment report.<br>*For example: What is the likely summer daytime high temperature for 2030-2050 in Sacramento?*\n",
     "\n",
     "### Work in Progress \n",
     "--------------------------------------\n",
@@ -96,7 +104,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "climakitae-tests",
    "language": "python",
    "name": "python3"
   },
@@ -110,7 +118,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary of changes and related issue
The following notebooks have been added to the navigation guide:
[Download_localized_stations.ipynb](https://github.com/cal-adapt/cae-notebooks/blob/main/collaborative/DFU/download_localized_stations.ipynb)
[Station_data_access.ipynb](https://github.com/cal-adapt/cae-notebooks/blob/main/collaborative/DFU/station_data_access.ipynb)
[Vulnerability_assessment.ipynb](https://github.com/cal-adapt/cae-notebooks/blob/main/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb)
[Historical_climate_data_comparisons.ipynb](https://github.com/cal-adapt/cae-notebooks/blob/main/exploratory/historical_climate_data_comparisons.ipynb)

This notebook link has been removed, as it does not appear to exist any longer: exploratory/climate_data_comparisons.ipynb

## Relevant motivation and context
This task was item 3 on the Feb 2025 Notebook update list.

## Type of Change

- [ ] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [x] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [ ] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
