### PR TITLE
Update timeseries_transformations notebook

### DIFF
--- a/analysis/timeseries_transformations.ipynb
+++ b/analysis/timeseries_transformations.ipynb
@@ -47,8 +47,8 @@
    "outputs": [],
    "source": [
     "selections = ckg.Select()\n",
-    "selections.area_average = 'Yes'"
-    "selections.scenario_ssp = ['SSP 3-7.0']"
+    "selections.area_average = 'Yes'",
+    "selections.scenario_ssp = ['SSP 3-7.0']",
     "selections.show()"
    ]
   },

--- a/analysis/timeseries_transformations.ipynb
+++ b/analysis/timeseries_transformations.ipynb
@@ -47,8 +47,8 @@
    "outputs": [],
    "source": [
     "selections = ckg.Select()\n",
-    "selections.area_average = 'Yes'",
-    "selections.scenario_ssp = ['SSP 3-7.0']",
+    "selections.area_average = 'Yes'\n",
+    "selections.scenario_ssp = ['SSP 3-7.0']\n",
     "selections.show()"
    ]
   },

--- a/analysis/timeseries_transformations.ipynb
+++ b/analysis/timeseries_transformations.ipynb
@@ -47,6 +47,8 @@
    "outputs": [],
    "source": [
     "selections = ckg.Select()\n",
+    "selections.area_average = 'Yes'"
+    "selections.scenario_ssp = ['SSP 3-7.0']"
     "selections.show()"
    ]
   },


### PR DESCRIPTION
## Summary of changes and related issue
Selections for area averaging and a default SSP (3-70) have been added to the selections cell. This allows users to run the notebook in its entirety without failures using default code.

## Relevant motivation and context
As-is, this notebook will fail in the section Steps 3 & 4: Visualize and Transform. The text does inform the user of which settings to edit, but it is more user-friendly to have the notebook run out-of-the-box without errors.

Closes #159 

## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
