### PR TITLE
Update TMY to use get_data()

### DIFF
--- a/work-in-progress/typical_meteorological_year_methodology.ipynb
+++ b/work-in-progress/typical_meteorological_year_methodology.ipynb
@@ -56,7 +56,8 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "from climakitae.util.utils import convert_to_local_time, get_closest_gridcell\n",
-    "from climakitae.core.data_export import write_tmy_file"
+    "from climakitae.core.data_export import write_tmy_file\n",
+    "from climakitae.core.data_interface import get_data"
    ]
   },
   {
@@ -107,6 +108,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf7bfcbd-eb4d-48fe-af35-1d81e842eb97",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(stn_code)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "5ba66963-c12f-4b47-8e37-b532fe8e38a0",
    "metadata": {},
@@ -138,33 +149,9 @@
    "metadata": {},
    "source": [
     "#### Step 1b: Variables in catalog\n",
-    "When selecting data, there are several considerations to be aware of. The recommended minimum input of data is 15-20 years worth of daily data. First, we will pre-load some data options to ensure that the same constraints are applied to every variable we retrieve from the catalog and calculate. It is important to note that not all models in the Cal-Adapt: Analytics Engine have the solar variables critical for TMY file generation - in fact, only 4 do! We will carefully subset our variables to ensure that the same 4 models are selected for consistency. We will also process the data for our designated station location (latitude, and longitude) at 9 km over the 1990-2020 period. For data post-2014, we will utilize SSP 3-7.0, although scenario selection in the near-future is relatively independent. If calculating a TMY for the far-future, **carefully consider which scenario SSP to include**, as there will be **significant** differences present. \n",
+    "When selecting data, there are several considerations to be aware of. The recommended minimum input of data is 15-20 years worth of daily data. It is important to note that not all models in the Cal-Adapt: Analytics Engine have the solar variables critical for TMY file generation - in fact, only 4 do! We will carefully subset our variables to ensure that the same 4 models are selected for consistency. We will also process the data for our designated station location (latitude, and longitude) at 9 km over the 1990-2020 period. An additional year (2021) is also loaded to pad the end of the dataset after converting to local time in the next few steps. For data post-2014, we will utilize SSP 3-7.0, although scenario selection in the near-future is relatively independent. If calculating a TMY for the far-future, **carefully consider which scenario SSP to include**, as there will be **significant** differences present. \n",
     "\n",
-    "Lastly, because the dynamically downscaled WRF data in the Cal-Adapt: Analytics Engine is in UTC time, we'll convert to the timezone of the station we've selected. This is particularly important for the timing of solar radiation max and min, which is a critical piece of a TMY. The handy `convert_to_local_time` function corrects for this, and ensures that all data within the same daily timestamp."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "57645bd8-517c-4de8-95fa-a565b66d0cb1",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "selections = ckg.Select()\n",
-    "\n",
-    "# default selections applicable to all variables selected\n",
-    "selections.data_type = \"Gridded\"\n",
-    "selections.area_average = \"Yes\"\n",
-    "selections.scenario_historical = [\"Historical Climate\"]\n",
-    "selections.scenario_ssp = [\"SSP 3-7.0\"] # Important based on time period considered!!\n",
-    "selections.time_slice = (1990, 2020)\n",
-    "selections.timescale = \"hourly\"\n",
-    "selections.resolution = \"9 km\"\n",
-    "selections.cached_area = ['coordinate selection']\n",
-    "selections.latitude = (stn_lat-0.08, stn_lat+0.08)\n",
-    "selections.longitude = (stn_lon-0.08, stn_lon+0.08)"
+    "Lastly, because the dynamically downscaled WRF data in the Cal-Adapt: Analytics Engine is in UTC time, we'll convert to the timezone of the station we've selected. This is particularly important for the timing of solar radiation max and min, which is a critical piece of a TMY. The handy `convert_to_local_time` function corrects for this, and ensures that all data are within the same daily timestamp."
    ]
   },
   {
@@ -185,7 +172,7 @@
    "id": "0799c331-5024-484d-beb2-cf97333aed9b",
    "metadata": {},
    "source": [
-    "Now that we have set up default settings, let's start retrieving data! We will need to calculate summary statistics and reduce to daily timescales for the following variables:"
+    "Now that we have set up the model list, let's start retrieving data! We will need to calculate summary statistics and reduce to daily timescales for the following variables:"
    ]
   },
   {
@@ -198,10 +185,21 @@
    "outputs": [],
    "source": [
     "# air temperature\n",
-    "selections.variable = \"Air Temperature at 2m\"\n",
-    "selections.units = \"degC\"\n",
-    "temp_data = selections.retrieve()\n",
-    "temp_data = convert_to_local_time(temp_data, selections) # convert to local timezone\n",
+    "temp_data = get_data(\n",
+    "    variable=\"Air Temperature at 2m\",\n",
+    "    resolution=\"9 km\",\n",
+    "    timescale=\"hourly\",\n",
+    "    data_type=\"Gridded\",\n",
+    "    units=\"degC\",\n",
+    "    latitude=(stn_lat-0.08, stn_lat+0.08),\n",
+    "    longitude=(stn_lon-0.08, stn_lon+0.08),\n",
+    "    area_average = \"Yes\",\n",
+    "    scenario=[\"Historical Climate\",\"SSP 3-7.0\"],\n",
+    "    time_slice=(1990, 2021),  # Short period for faster demonstration, extra year at end for local time conversion\n",
+    ")\n",
+    "\n",
+    "temp_data = convert_to_local_time(temp_data,stn_lon,stn_lat) # convert to local timezone, provide lon/lat because area average data lacks coordinates\n",
+    "temp_data = temp_data.sel({\"time\":slice(\"1990-01-01\",\"2020-12-31\")}) # these dates should be your desired time period\n",
     "temp_data = temp_data.sel(simulation = data_models)\n",
     "\n",
     "# max air temp\n",
@@ -243,10 +241,21 @@
    "outputs": [],
    "source": [
     "# wind speed\n",
-    "selections.variable = \"Wind speed at 10m\"\n",
-    "selections.units = \"m s-1\"\n",
-    "ws_data = selections.retrieve()\n",
-    "ws_data = convert_to_local_time(ws_data, selections) # convert to local timezone\n",
+    "ws_data = get_data(\n",
+    "    variable=\"Wind speed at 10m\",\n",
+    "    resolution=\"9 km\",\n",
+    "    timescale=\"hourly\",\n",
+    "    data_type=\"Gridded\",\n",
+    "    units=\"m s-1\",\n",
+    "    latitude=(stn_lat-0.08, stn_lat+0.08),\n",
+    "    longitude=(stn_lon-0.08, stn_lon+0.08),\n",
+    "    area_average = \"Yes\",\n",
+    "    scenario=[\"Historical Climate\",\"SSP 3-7.0\"],\n",
+    "    time_slice=(1990, 2021),  # Short period for faster demonstration, extra year at end for local time conversion\n",
+    ")\n",
+    "\n",
+    "ws_data = convert_to_local_time(ws_data,stn_lon,stn_lat) # convert to local timezone, provide lon/lat because area average data lacks coordinates\n",
+    "ws_data = ws_data.sel({\"time\":slice(\"1990-01-01\",\"2020-12-31\")}) # your desired time slice in local time\n",
     "ws_data = ws_data.sel(simulation = data_models)\n",
     "\n",
     "# max wind speed\n",
@@ -276,10 +285,21 @@
    "outputs": [],
    "source": [
     "# dew point temperature\n",
-    "selections.variable = \"Dew point temperature\"\n",
-    "selections.units = \"degC\"\n",
-    "dewpt_data = selections.retrieve()\n",
-    "dewpt_data = convert_to_local_time(dewpt_data, selections) # convert to local timezone\n",
+    "dewpt_data = get_data(\n",
+    "    variable=\"Dew point temperature\",\n",
+    "    resolution=\"9 km\",\n",
+    "    timescale=\"hourly\",\n",
+    "    data_type=\"Gridded\",\n",
+    "    units=\"degC\",\n",
+    "    latitude=(stn_lat-0.08, stn_lat+0.08),\n",
+    "    longitude=(stn_lon-0.08, stn_lon+0.08),\n",
+    "    area_average = \"Yes\",\n",
+    "    scenario=[\"Historical Climate\",\"SSP 3-7.0\"],\n",
+    "    time_slice=(1990, 2021),  # Short period for faster demonstration, extra year at end for local time conversion\n",
+    ")\n",
+    "\n",
+    "dewpt_data = convert_to_local_time(dewpt_data,stn_lon,stn_lat) # convert to local timezone, provide lon/lat because area average data lacks coordinates\n",
+    "dewpt_data = dewpt_data.sel({\"time\":slice(\"1990-01-01\",\"2020-12-31\")}) # your desired time slice in local time\n",
     "dewpt_data = dewpt_data.sel(simulation = data_models)\n",
     "\n",
     "# max dew point\n",
@@ -313,9 +333,20 @@
    "outputs": [],
    "source": [
     "# global irradiance\n",
-    "selections.variable = \"Instantaneous downwelling shortwave flux at bottom\"\n",
-    "global_irradiance_data = selections.retrieve()\n",
-    "global_irradiance_data = convert_to_local_time(global_irradiance_data, selections) # convert to local timezone\n",
+    "global_irradiance_data = get_data(\n",
+    "    variable=\"Instantaneous downwelling shortwave flux at bottom\",\n",
+    "    resolution=\"9 km\",\n",
+    "    timescale=\"hourly\",\n",
+    "    data_type=\"Gridded\",\n",
+    "    latitude=(stn_lat-0.08, stn_lat+0.08),\n",
+    "    longitude=(stn_lon-0.08, stn_lon+0.08),\n",
+    "    area_average = \"Yes\",\n",
+    "    scenario=[\"Historical Climate\",\"SSP 3-7.0\"],\n",
+    "    time_slice=(1990, 2021),  # Short period for faster demonstration, extra year at end for local time conversion\n",
+    ")\n",
+    "\n",
+    "global_irradiance_data = convert_to_local_time(global_irradiance_data,stn_lon,stn_lat) # convert to local timezone, provide lon/lat because area average data lacks coordinates\n",
+    "global_irradiance_data = global_irradiance_data.sel({\"time\":slice(\"1990-01-01\",\"2020-12-31\")}) # your desired time slice in local time\n",
     "global_irradiance_data = global_irradiance_data.sel(simulation = data_models)\n",
     "\n",
     "global_irradiance_data.name = \"Global horizontal irradiance\" # rename for clarity\n",
@@ -332,9 +363,20 @@
    "outputs": [],
    "source": [
     "# direct normal irradiance\n",
-    "selections.variable = \"Shortwave surface downward direct normal irradiance\"\n",
-    "direct_irradiance_data = selections.retrieve()\n",
-    "direct_irradiance_data = convert_to_local_time(direct_irradiance_data, selections) # convert to local timezone\n",
+    "direct_irradiance_data = get_data(\n",
+    "    variable=\"Shortwave surface downward direct normal irradiance\",\n",
+    "    resolution=\"9 km\",\n",
+    "    timescale=\"hourly\",\n",
+    "    data_type=\"Gridded\",\n",
+    "    latitude=(stn_lat-0.08, stn_lat+0.08),\n",
+    "    longitude=(stn_lon-0.08, stn_lon+0.08),\n",
+    "    area_average = \"Yes\",\n",
+    "    scenario=[\"Historical Climate\",\"SSP 3-7.0\"],\n",
+    "    time_slice=(1990, 2021),  # Short period for faster demonstration, extra year at end for local time conversion\n",
+    ")\n",
+    "\n",
+    "direct_irradiance_data = convert_to_local_time(direct_irradiance_data,stn_lon,stn_lat) # convert to local timezone, provide lon/lat because area average data lacks coordinates\n",
+    "direct_irradiance_data = direct_irradiance_data.sel({\"time\":slice(\"1990-01-01\",\"2020-12-31\")}) # your desired time slice in local time\n",
     "direct_irradiance_data = direct_irradiance_data.sel(simulation = data_models)\n",
     "\n",
     "direct_irradiance_data.name = \"Direct normal irradiance\" # rename for clarity\n",
@@ -845,28 +887,26 @@
     "        'Wind direction at 10m':'degrees',\n",
     "        'Surface Pressure':'Pa'\n",
     "    }\n",
-    "    \n",
-    "    # Set up shared catalog access settings\n",
-    "    selections.data_type = \"Gridded\"\n",
-    "    selections.area_average = \"No\"\n",
-    "    selections.scenario_historical = [\"Historical Climate\"]\n",
-    "    selections.scenario_ssp = [\"SSP 3-7.0\"] # Important based on time period considered!!\n",
-    "    selections.timescale = \"hourly\"\n",
-    "    selections.resolution = \"9 km\"\n",
-    "    selections.cached_area = ['coordinate selection']\n",
-    "    selections.latitude = (stn_lat-0.08, stn_lat+0.08)\n",
-    "    selections.longitude = (stn_lon-0.08, stn_lon+0.08)\n",
-    "    selections.time_slice = (1990, 2020)\n",
     "\n",
     "    # Loop through each variable and grab data from catalog \n",
     "    all_vars_list = []\n",
     "    print(\"STEP 1: RETRIEVING HOURLY DATA FROM CATALOG\\n\")\n",
     "    for var, units in vars_and_units.items(): \n",
     "        print(\"Retrieving data for {0}\".format(var), end=\"... \")\n",
-    "        selections.variable = var # Set variable\n",
-    "        selections.units = units # Set units  \n",
-    "        data_by_var = selections.retrieve() # Retrieve data from catalog\n",
-    "        data_by_var = convert_to_local_time(data_by_var, selections) # convert to local timezone\n",
+    "        data_by_var = get_data(\n",
+    "            variable=var,\n",
+    "            resolution=\"9 km\",\n",
+    "            timescale=\"hourly\",\n",
+    "            data_type=\"Gridded\",\n",
+    "            units=units,\n",
+    "            latitude=(stn_lat-0.08, stn_lat+0.08),\n",
+    "            longitude=(stn_lon-0.08, stn_lon+0.08),\n",
+    "            area_average = \"No\",\n",
+    "            scenario=[\"Historical Climate\",\"SSP 3-7.0\"],\n",
+    "            time_slice=(1990, 2021),  # Short period for faster demonstration. Add extra year at end for local time conversion\n",
+    "        )\n",
+    "        data_by_var = convert_to_local_time(data_by_var) # convert to local timezone.\n",
+    "        data_by_var = data_by_var.sel({\"time\":slice(\"1990-01-01\",\"2020-12-31\")}) # get desired time slice in local time\n",
     "        data_by_var = get_closest_gridcell(data_by_var, stn_lat, stn_lon, print_coords=False) # retrieve only closest gridcell\n",
     "        data_by_var = data_by_var.sel(simulation = data_models) # Subset for only the models that have solar variables\n",
     "\n",
@@ -952,6 +992,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e18163a-5a43-4c91-ab1c-924673fc9bb6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmy_data_to_export[simulation].columns"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "9951a416-b2bf-4924-84b2-f5fd409913bc",
    "metadata": {},
@@ -1001,6 +1051,22 @@
     "    filename = 'TMY_{0}_{1}'.format(stn_name.replace(\" \", \"_\").replace(\"(\",\"\").replace(\")\",\"\"), sim).lower()\n",
     "    write_tmy_file(filename, tmy_data_to_export[sim], stn_name, stn_code, stn_lat, stn_lon, stn_state, file_ext=\"epw\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa5b2a35-282f-44ce-9210-7d460bb7c3ab",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a93a8373-cc0f-452c-8f38-837b15079360",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1019,7 +1085,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary of changes and related issue
The data loading workflows have been changed to use get_data(). I've updated the convert_to_local_time() calls to use the new syntax and added additional time slicing because that capability will no longer be part of convert_to_local_time.

## Relevant motivation and context
The convert_to_local_time() function is changing to be used with the get_data() framework. This is a breaking change that requires updating this notebook.

## Type of Change

- [ ] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [ ] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [ ] Notebook raises appropriate error messages for common user errors
- [ ] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
