### PR TITLE
Addressing t=0 condition for 1 in X insertion into 8760s

### DIFF
--- a/collaborative/IOU/8760/phase3.py
+++ b/collaborative/IOU/8760/phase3.py
@@ -509,10 +509,17 @@ def extract_event_windows(
         return dummy
 
     # Create time slices for each event
-    time_slices = [
-        slice(dt - timedelta(days=t), dt + timedelta(days=t) if t > 0 else dt)
-        for dt in event_times
-    ]
+    if t == 0:
+        time_slices = [
+            slice(dt - timedelta(hours=12), dt + timedelta(hours=12))
+            for dt in event_times
+        ]
+
+    else:
+        time_slices = [
+            slice(dt - timedelta(days=t), dt + timedelta(days=t))
+            for dt in event_times
+        ]
 
     # Extract windows and reassign time axis
     windows = [
@@ -578,8 +585,12 @@ def insert_data(
     Returns:
         xr.DataArray: Copy of `orig_data` with `to_insert` injected into the specified time window.
     """
-    start = int(center_time) - 24 * t
-    end = int(center_time) + 24 * t + 1
+    # Edge case for t=0, grab +/- 12 hours from the max event time
+    if t == 0:
+        t = 0.5
+
+    start = int(int(center_time) - 24 * t)
+    end = int(int(center_time) + 24 * t + 1)
 
     result = orig_data.copy()
     result[start:end] = to_insert
@@ -659,6 +670,7 @@ def plot_modified8760s(
 
             # ax.set_ylim(top=110)
 
+    # plt.xlim(left=4500, right=5500)
     plt.tight_layout()
     plt.show()
 


### PR DESCRIPTION
## Summary of changes and related issue
Addressing t=0 condition for 1 in X event insertion into 8760s by grabbing the 12 hours before and after the event, along with the event itself, and inserting that into the 8760.

## Relevant motivation and context
We want to include a little 'ramping up' and 'ramping down' information into the 8760 around this 1-in-X event, rather than it just being an immediate spike up/down in the 8760.

## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [ ] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [ ] Notebook raises appropriate error messages for common user errors
- [ ] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
