### PR TITLE
Update HDP station access: area subsetting and plot

### DIFF
--- a/data-access/weather_station_data_access.ipynb
+++ b/data-access/weather_station_data_access.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "The <span style=\"color:#FF0000\">[Historical Observations Data Platform](https://eaglerockanalytics.com/project/historical-observations-data-platform/)</span> is a cloud-based historical weather observations database that enables access to high-quality, open climate and weather data. The Platform responds to a broad-scale need to understand weather and climate information including the severity, duration, frequency, and rate of change over time of extreme weather events, as well as supporting projections downscaling efforts. The Platform implements stringent, customized Quality Assurance / Quality Control (QA/QC) protocols in line with international conventions, with updates relevant to the energy sector to accurate capture extremes. The Platform has sourced publicly accessible weather observation stations from 27 networks throughout western North America, with a total of **14,927 quality-controlled and standardized stations** spanning 1980-2022. \n",
     "\n",
-    "For more information on the QA/QC and standardization process, please check out the open-access methods and code at the <span style=\"color:#FF0000\">[Historical Observations Data Platform code repository](https://github.com/Eagle-Rock-Analytics/historical-obs-platform)</span>."
+    "For more information on the QA/QC and standardization process, please check out the open-access methods and code at the <span style=\"color:#FF0000\">[Historical Observations Data Platform code repository](https://github.com/Eagle-Rock-Analytics/historical-obs-platform)</span>. A station list of all available quality-controlled and standardized stations is available in <span style=\"color:#FF0000\">[climakitae](https://github.com/cal-adapt/climakitae/blob/data/add-hdp-stnlist/climakitae/data/historical_wx_stations.csv)</span>."
    ]
   },
   {
@@ -116,7 +116,7 @@
     "# Set your query here \n",
     "query = {\n",
     "    \"network_id\": \"ASOSAWOS\",  # Name of the network\n",
-    "    \"station_id\": [\"ASOSAWOS_A0002694297\",\"ASOSAWOS_A0704900320\",\"ASOSAWOS_72020200118\"] # List of stations to get data for \n",
+    "    \"station_id\": [\"ASOSAWOS_72288023152\",\"ASOSAWOS_72389093193\",\"ASOSAWOS_72297603166\",\"ASOSAWOS_72493023230\"] # List of stations to get data for \n",
     "}\n",
     "\n",
     "# Subset catalog \n",
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "# Retrieve a single file\n",
-    "ds = dsets[\"ASOSAWOS.ASOSAWOS_72020200118\"]\n",
+    "ds = dsets[\"ASOSAWOS.ASOSAWOS_72389093193\"]\n",
     "ds"
    ]
   },
@@ -209,11 +209,100 @@
     "variable_to_plot = \"tas\"\n",
     "ds.squeeze()[variable_to_plot].plot(x=\"time\");"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdfb215d-ab20-4bc5-bce8-4be8fc29c1f5",
+   "metadata": {},
+   "source": [
+    "## Subset the historical weather stations for a region\n",
+    "\n",
+    "If you're interested in historical weather observation stations in a specific area, you can also subset the full archive of stations to identify those that you are interested in. We will read in the Historical Data Platform station list, which provides the coordinates, dates of coverage, source network, and *total number of observations* for each station. We'll soon be adding additional information like the state and common station identifiers!\n",
+    "\n",
+    "For this, we'll use an area shapefile; upload your own to see which stations are in your area! You can pass either a **web link to an open access shapefile**, or **upload your own shapefile** to your Hub instance too. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "400f678f-6b2c-4fe5-bf2d-b4c3894ade33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in the Historical Data Platform station list\n",
+    "import geopandas as gpd\n",
+    "from climakitae.util.utils import read_csv_file, clip_gpd_to_shapefile\n",
+    "\n",
+    "hdp_stns = read_csv_file(\"data/historical_wx_stations.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0a0d6d0-7139-4836-94fb-80efa9efb323",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Region of Interest shapefile\n",
+    "roi = gpd.read_file(\"...\") # Replace this with your own shapefile!\n",
+    "\n",
+    "# If there are multiple polygons within the shapefile and you want to further subset, you will need to do so.\n",
+    "# Example\n",
+    "# roi = roi[roi[\"NAME\"] == \"SPECIFIC_AREA\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b564c79-28e1-4a2f-9d10-4e693d092de3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clip the stationlist to subset within your area of interest\n",
+    "stns_within_area = clip_gpd_to_shapefile(hdp_stns, roi)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f16c24b2-f50e-43f4-a7e5-f4615e967248",
+   "metadata": {},
+   "source": [
+    "This subset are the stations within the designated area from your submitted shapefile! You can easily export this list now for your own information, and use it to look up specific stations. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4386c14-98a7-40f9-8c5c-00e0250e4fe3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Export the subset portion of station list\n",
+    "stns_within_area.to_csv(\"subset_station_list.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16e7664d-cc10-4762-8205-d12371e6b626",
+   "metadata": {},
+   "source": [
+    "Want a more interactive way to zoom in on an area? use `stns.explore()`! Note, it may take some time to load. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b751f5d7-79d0-406f-8967-2cedd181a3d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stns_within_area.explore()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "climakitae",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -227,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/data-access/weather_station_data_access.ipynb
+++ b/data-access/weather_station_data_access.ipynb
@@ -243,8 +243,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Region of Interest shapefile\n",
+    "# Region of Interest shapefile, and set coordinate reference system\n",
     "roi = gpd.read_file(\"...\") # Replace this with your own shapefile!\n",
+    "roi = roi.to_crs(\"EPSG:3857\")\n",
     "\n",
     "# If there are multiple polygons within the shapefile and you want to further subset, you will need to do so.\n",
     "# Example\n",


### PR DESCRIPTION
## Summary of changes and related issue
Added additional functionality for a user to add their own shapefile to identify stations within an area of interest. Users can also export the station list for further info. 

## Relevant motivation and context
User is asking to find stations within their area. 

## Type of Change
- [ ] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
