### PR TITLE
Fix typo in imported path variable name for vulnerability notebook

### DIFF
--- a/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
+++ b/collaborative/IOU/vulnerability_assessment/vulnerability_assessment.ipynb
@@ -67,9 +67,9 @@
    "outputs": [],
    "source": [
     "# Read in dummy locations from `stations_csv` file\n",
-    "from climakitae.core.paths import stations_csv_path\n",
+    "from climakitae.core.paths import STATIONS_CSV_PATH\n",
     "from climakitae.util.utils import read_csv_file\n",
-    "example_locs = read_csv_file(stations_csv_path, index_col=0)[['LAT_Y', 'LON_X']].rename(columns={'LAT_Y': 'lat', 'LON_X': 'lon'})"
+    "example_locs = read_csv_file(STATIONS_CSV_PATH, index_col=0)[['LAT_Y', 'LON_X']].rename(columns={'LAT_Y': 'lat', 'LON_X': 'lon'})"
    ]
   },
   {
@@ -645,7 +645,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "climakitae",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
## Summary of changes and related issue
Fix typo in imported path variable name for vulnerability notebook.
This must be an outdated variable name that was not updated here. 
I just happened to notice this when reviewing something else. 

## Relevant motivation and context
The notebook does not run as is without this fix. 

## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
