### PR TITLE
Link to HDP file in cadcat. Improve subset example

### DIFF
--- a/data-access/weather_station_data_access.ipynb
+++ b/data-access/weather_station_data_access.ipynb
@@ -9,7 +9,9 @@
     "\n",
     "The <span style=\"color:#FF0000\">[Historical Observations Data Platform](https://eaglerockanalytics.com/project/historical-observations-data-platform/)</span> is a cloud-based historical weather observations database that enables access to high-quality, open climate and weather data. The Platform responds to a broad-scale need to understand weather and climate information including the severity, duration, frequency, and rate of change over time of extreme weather events, as well as supporting projections downscaling efforts. The Platform implements stringent, customized Quality Assurance / Quality Control (QA/QC) protocols in line with international conventions, with updates relevant to the energy sector to accurate capture extremes. The Platform has sourced publicly accessible weather observation stations from 27 networks throughout western North America, with a total of **14,927 quality-controlled and standardized stations** spanning 1980-2022. \n",
     "\n",
-    "For more information on the QA/QC and standardization process, please check out the open-access methods and code at the <span style=\"color:#FF0000\">[Historical Observations Data Platform code repository](https://github.com/Eagle-Rock-Analytics/historical-obs-platform)</span>. A station list of all available quality-controlled and standardized stations is available in <span style=\"color:#FF0000\">[climakitae](https://github.com/cal-adapt/climakitae/blob/data/add-hdp-stnlist/climakitae/data/historical_wx_stations.csv)</span>."
+    "For more information on the QA/QC and standardization process, please check out the open-access methods and code at the <span style=\"color:#FF0000\">[Historical Observations Data Platform code repository](https://github.com/Eagle-Rock-Analytics/historical-obs-platform)</span>. A station list of all available quality-controlled and standardized stations is available in our <span style=\"color:#FF0000\">[data bucket](https://cadcat.s3.amazonaws.com/histwxstns/historical_wx_stations.csv)</span>.\n",
+    "\n",
+    "**Runtime**: < 1 min"
    ]
   },
   {
@@ -19,7 +21,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import intake "
+    "import intake \n",
+    "import pandas as pd\n",
+    "import geopandas as gpd\n",
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -217,9 +222,11 @@
    "source": [
     "## Subset the historical weather stations for a region\n",
     "\n",
-    "If you're interested in historical weather observation stations in a specific area, you can also subset the full archive of stations to identify those that you are interested in. We will read in the Historical Data Platform station list, which provides the coordinates, dates of coverage, source network, and *total number of observations* for each station. We'll soon be adding additional information like the state and common station identifiers!\n",
+    "If you're interested in historical weather observation stations in a specific area, you can also subset the full archive of stations to identify those that you are interested in. We will read in the Historical Data Platform station list, which provides the coordinates, dates of coverage, source network, location information, and the *total number of observations* for each station. \n",
     "\n",
-    "For this, we'll use an area shapefile; upload your own to see which stations are in your area! You can pass either a **web link to an open access shapefile**, or **upload your own shapefile** to your Hub instance too. "
+    "For this example, we will show you how to read a shapefile of historic wildfire boundaries in San Diego country using publically available data from the [San Diego Regional Data Warehouse](https://geo.sandag.org/portal/apps/experiencebuilder/experience/?id=fad9e9c038c84f799b5378e4cc3ed068#data_s=id%3AdataSource_1-0%3A202). Next, we'll subset the station list to get all the weather stations available in the fire zone for the [Cedar fire in 2003](https://www.sandiego.gov/fire/about/major-fires-incidents/2003-cedar-fire), which is one of the largest wildfires in California's history (and, as of 2025, the largest wildfire in San Diego county). Lastly, we'll export the subsetted station list and make a plot of the fire boundary with the station locations overlayed. \n",
+    "\n",
+    "You could easily modify this workflow for your own shapefiles, by using **web link to an open access shapefile** or **uploading your own shapefile** to your Hub instance."
    ]
   },
   {
@@ -230,10 +237,18 @@
    "outputs": [],
    "source": [
     "# Read in the Historical Data Platform station list\n",
-    "import geopandas as gpd\n",
-    "from climakitae.util.utils import read_csv_file, clip_gpd_to_shapefile\n",
+    "hdp_stns = pd.read_csv(\"https://cadcat.s3.amazonaws.com/histwxstns/historical_wx_stations.csv\")\n",
     "\n",
-    "hdp_stns = read_csv_file(\"data/historical_wx_stations.csv\")"
+    "# Convert to a GeoDataFrame so we can use the geometry column for subsetting\n",
+    "hdp_stns = gpd.GeoDataFrame(hdp_stns, geometry=gpd.GeoSeries.from_wkt(hdp_stns[\"geometry\"]), crs=\"EPSG:4326\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "959c22c7",
+   "metadata": {},
+   "source": [
+    "The open source Python library [geopandas](https://geopandas.org/en/stable/getting_started/introduction.html) makes working with shapefiles in python easy; you can read in a shapefile using one line of code. "
    ]
   },
   {
@@ -243,13 +258,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Region of Interest shapefile, and set coordinate reference system\n",
-    "roi = gpd.read_file(\"...\") # Replace this with your own shapefile!\n",
-    "roi = roi.to_crs(\"EPSG:3857\")\n",
+    "# Region of Interest shapefile\n",
+    "roi = gpd.read_file(\"https://geo.sandag.org/server/rest/directories/downloads/Fire_Burn_History_shapefile.zip\") # Replace this with your own shapefile!\n",
     "\n",
-    "# If there are multiple polygons within the shapefile and you want to further subset, you will need to do so.\n",
-    "# Example\n",
-    "# roi = roi[roi[\"NAME\"] == \"SPECIFIC_AREA\"]"
+    "# Convert to projection of HDP data\n",
+    "roi = roi.to_crs(hdp_stns.crs) \n",
+    "\n",
+    "# Subset the shapefile to just get the Cedar fire of 2003 \n",
+    "cedar_fire_2003 = roi[(roi[\"FIRE_NAME\"]==\"CEDAR\") & (roi[\"YEAR_\"] == 2003)]\n",
+    "cedar_fire_2003"
    ]
   },
   {
@@ -260,7 +277,7 @@
    "outputs": [],
    "source": [
     "# Clip the stationlist to subset within your area of interest\n",
-    "stns_within_area = clip_gpd_to_shapefile(hdp_stns, roi)"
+    "stns_within_area = gpd.sjoin(hdp_stns, cedar_fire_2003, how='inner', predicate='intersects').reset_index(drop=True)"
    ]
   },
   {
@@ -274,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4386c14-98a7-40f9-8c5c-00e0250e4fe3",
+   "id": "ed5b6ad3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,10 +301,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "586e884a",
+   "metadata": {},
+   "source": [
+    "Let's also make a quick visualization of the data to better understand the subsetting process and the geographic boundaries of the data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31af2c20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8,10))\n",
+    "cedar_fire_2003.plot(ax=ax, color='rosybrown')\n",
+    "stns_within_area.plot(ax=ax, color='darkblue', markersize=12, label=\"station\")\n",
+    "ax.legend()\n",
+    "ax.set_title(\"Weather stations within the Cedar Fire boundary\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "16e7664d-cc10-4762-8205-d12371e6b626",
    "metadata": {},
    "source": [
-    "Want a more interactive way to zoom in on an area? use `stns.explore()`! Note, it may take some time to load. "
+    "Want a more interactive way to view the data? Use `stns.explore()`, a geopandas method that will generate an interactive map where you can zoom, pan, and click features to see their attributes. Note, this map may take some time to load. "
    ]
   },
   {
@@ -303,7 +342,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "climakitae",
    "language": "python",
    "name": "python3"
   },
@@ -317,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary of changes and related issue
- The notebook links to the HDP station list file in cadcat, instead of climakitae, where it will be deleted. 
- I also updated the station subsetting example (see below for more details) 
- Added expected runtime to top of notebook

## Relevant motivation and context
The previous subsetting section used code that the user was supposed to fill in, which results in errors being raised if the user actually ran the code cells without changing anything. It also referenced a function in `climakitae` for subsetting that is overengineered for the file in cadcat, which provides a geometry column. Lastly, it forced the shapefile to EPSG:3857, presumably to match the HDP data, but this is not actually the CRS of the HDP data. 

Anyways I used some creativity to come up with what I thought was a better example of how to subset using a shapefile! Now, the cells all run without error, and I think its a good and hopefully relevant example for our stakeholders. LMK what you think! 

## Type of Change

- [x] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [x] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
