### PR TITLE
Revert "Updating basic data access notebook for new core "

### DIFF
--- a/data-access/basic_data_access.ipynb
+++ b/data-access/basic_data_access.ipynb
@@ -6,9 +6,7 @@
    "metadata": {},
    "source": [
     "# Basic data access \n",
-    "This notebook showcases helper functions from `climakitae` that enable you to access and export the AE catalog data, while also allowing you to perform spatial subsetting and view the data options in an easy-to-use fashion. These functions could be easily implemented in a python script.\n",
-    "\n",
-    "**Runtime**: < 1 min"
+    "This notebook showcases helper functions from `climakitae` that enable you to access and export the AE catalog data, while also allowing you to perform spatial subsetting and view the data options in an easy-to-use fashion. These functions could be easily implemented in a python script."
    ]
   },
   {
@@ -19,7 +17,11 @@
    "outputs": [],
    "source": [
     "import climakitae as ck \n",
-    "from climakitae.new_core.user_interface import ClimateData"
+    "from climakitae.core.data_interface import (\n",
+    "    get_data_options, \n",
+    "    get_subsetting_options, \n",
+    "    get_data\n",
+    ")"
    ]
   },
   {
@@ -28,7 +30,7 @@
    "metadata": {},
    "source": [
     "## High-level details \n",
-    "The AE data catalog has many different types of data. Our helper library `climakitae` attempts to make accessing and retrieving this data intuitive, as well as simplify climate and statistical analysis with the data down the line, by performing some data transformations as the data is retrieved.<br><br> To retrieve the data, you'll need to make some selections as to your climate variable, data resolution, location settings, and many other options. There are also several high-level options you'll need to set when selecting your data, detailed below: \n",
+    "The AE data catalog has many different types of data. Our helper library `climakitae` attempts to make accessing and retrieveing this data intuitive, as well as simplify climate and statistical analysis with the data down the line, by performing some data transformations as the data is retrieved.<br><br> To retrieve the data, you'll need to make some selections as to your climate variable, data resolution, location settings, and many other options. There are also several high-level options you'll need to set when selecting your data, detailed below: \n",
     "\n",
     "### Data type: Gridded or Stations\n",
     "**Gridded**: Gridded (i.e. raster) climate data at various spatial resolutions.<br><br>\n",
@@ -45,10 +47,10 @@
     "\n",
     "**Warming Level**: Retrieve the data by future global warming levels, which will automatically retrieve all available model data for the historical+future period and then calculate the time window around which each simulation reaches the selected warming level.  \n",
     "- Because warming levels are defined based on amount of global mean temperature change, they can be used to compare possible outcomes across multiple scenarios or model simulations.\n",
-    "- This approach includes all simulations that reach a specified amount of warming regardless of when they reach that level of warming, rather than the time-based approach, which will preliminarily subset a portion of simulations that follow a given SSP trajectory.\n",
+    "- This approach includes all simulations that reach a specified amount of warming regardless of when they reach that level of warming, rather than the time-based appraoch, which will preliminarily subset a portion of simulations that follow a given SSP trajectory.\n",
     "    \n",
     "### Downscaling method: Dynamical, Statistical, or both\n",
-    "**Dynamical**: [Dynamically downscaled](https://dept.atmos.ucla.edu/alexhall/downscaling-cmip6) WRF data, produced at hourly intervals. If you select 'daily' or 'monthly' for 'Timescale', you will receive an average of the hourly data. The spatial resolution options, on the other hand, are each the output of a different simulation, nesting to higher resolution over smaller areas.<br><br>\n",
+    "**Dynamical**:[Dynamically downscaled](https://dept.atmos.ucla.edu/alexhall/downscaling-cmip6) WRF data, produced at hourly intervals. If you select 'daily' or 'monthly' for 'Timescale', you will receive an average of the hourly data. The spatial resolution options, on the other hand, are each the output of a different simulation, nesting to higher resolution over smaller areas.<br><br>\n",
     "**Statistical**: [Hybrid-statistically downscaled](https://loca.ucsd.edu) LOCA2-Hybrid data, available at daily and monthly timescales. Multiple LOCA2-Hybrid simulations are available (100+) at a fine spatial resolution of 3km."
    ]
   },
@@ -57,8 +59,8 @@
    "id": "1750153d-4aec-4011-8345-9ceb5d9e2fa8",
    "metadata": {},
    "source": [
-    "## See the options in our data catalog\n",
-    "The interface provides several methods to explore available data options. You can get a comprehensive overview or explore step by step."
+    "## See the options in our data catalog in a table\n",
+    "This function returns a pandas DataFrame (i.e. a table) of our data options. You can also use the library `climakitaegui` to visualize these options in an interactive panel. See the notebook `interactive_data_access_and_viz.ipynb` to explore that approach. "
    ]
   },
   {
@@ -70,11 +72,7 @@
    },
    "outputs": [],
    "source": [
-    "# Initialize the interface\n",
-    "cd = ClimateData()\n",
-    "\n",
-    "# Get a comprehensive overview of all available options\n",
-    "cd.show_all_options()"
+    "get_data_options()"
    ]
   },
   {
@@ -83,7 +81,7 @@
    "metadata": {},
    "source": [
     "## See the data options for a particular subset of inputs\n",
-    "You can explore options step by step, building your query as you learn about available data."
+    "The `get_data_options` function enables you to input a number of different function arguments, corresponding to the columns in the table above, to subset the table. Inputting no arguments, like we did above, will return the entire range of options.<br><br>First, lets print the function documentation to see the inputs and outputs of the function. If an argument (or \"parameter\", as listed in the documentation) is listed as \"optional\", that means you don't have to input anything for that argument. In the case of this function, none of the function arguments are required, so you can simply call the function. "
    ]
   },
   {
@@ -95,17 +93,7 @@
    },
    "outputs": [],
    "source": [
-    "# Explore options step by step\n",
-    "print(\"=== Available Catalogs ===\")\n",
-    "cd.show_catalog_options()\n",
-    "\n",
-    "print(\"\\n=== Choose 'renewable energy generation' catalog and explore installations ===\")\n",
-    "renewables_explorer = cd.catalog(\"renewable energy generation\")\n",
-    "renewables_explorer.show_installation_options()\n",
-    "\n",
-    "print(\"\\n=== Choose 'pv_utility' installation and explore variables ===\")\n",
-    "pv_explorer = renewables_explorer.installation(\"pv_utility\")\n",
-    "pv_explorer.show_variable_options()"
+    "print(get_data_options.__doc__)"
    ]
   },
   {
@@ -113,7 +101,7 @@
    "id": "c9c1e03c-a414-4b5b-94d3-1ec2b01573a1",
    "metadata": {},
    "source": [
-    "You can also explore the climate data catalog:"
+    "If you call the function with **no inputs**, it will simply return the entire catalog! But, let's say you want to see all the data options for statistically downscaled data at 3 km resolution. You'll want to provide inputs for the `downscaling_method` and `resolution` arguments. "
    ]
   },
   {
@@ -125,21 +113,26 @@
    },
    "outputs": [],
    "source": [
-    "print(\"=== Climate Data Catalog ===\")\n",
-    "cd = ClimateData()\n",
-    "data_explorer = cd.catalog(\"cadcat\")\n",
-    "\n",
-    "print(\"\\n=== WRF (Dynamical Downscaling) Variables ===\")\n",
-    "wrf_explorer = data_explorer.activity_id(\"WRF\")\n",
-    "wrf_explorer.show_variable_options()"
+    "get_data_options(\n",
+    "    downscaling_method = \"Statistical\", \n",
+    "    resolution = \"3 km\"\n",
+    ")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "a222cad5-89cd-4ec2-8b76-fca3f764e247",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-12T17:42:00.445033Z",
+     "iopub.status.busy": "2024-07-12T17:42:00.444642Z",
+     "iopub.status.idle": "2024-07-12T17:42:00.482082Z",
+     "shell.execute_reply": "2024-07-12T17:42:00.480999Z",
+     "shell.execute_reply.started": "2024-07-12T17:42:00.445010Z"
+    }
+   },
    "source": [
-    "At any point in building your query, you can check what parameters you've set:"
+    "Perhaps you want to see all the data options for daily precipitation. We have several precipitation options in the catalog. You don't need to know the name of these variables; simply use \"precipitation\" as your input to the function for the `variable` argument.<br><br>The function prefers that your inputs match an actual option in the catalog-- with exact capitalizations and no misspelling-- and will print a warning if your input is not a direct match (\"precipitation\" is not an option, but \"Precipitation (total)\" is). The function will then try to make a guess as to what you actually meant. "
    ]
   },
   {
@@ -151,22 +144,10 @@
    },
    "outputs": [],
    "source": [
-    "# Build a partial query and check its state\n",
-    "cd = ClimateData()\n",
-    "partial_query = (cd\n",
-    "    .catalog(\"cadcat\")\n",
-    "    .activity_id(\"WRF\")\n",
-    "    .experiment_id(\"historical\")\n",
-    "    .table_id(\"mon\")\n",
-    "    .grid_label(\"d01\")\n",
-    ")\n",
-    "\n",
-    "# Check what we've built so far\n",
-    "partial_query.show_query()\n",
-    "\n",
-    "# See what variable options are still available\n",
-    "print(\"\\nAvailable variables for this query:\")\n",
-    "partial_query.show_variable_options()"
+    "get_data_options(\n",
+    "    variable = \"precipitation\", \n",
+    "    timescale = \"daily\"\n",
+    ") "
    ]
   },
   {
@@ -174,7 +155,7 @@
    "id": "5f8260ed-adff-4c49-86ff-69ec207da04d",
    "metadata": {},
    "source": [
-    "You can reset the interface to start a new query at any time:"
+    "The function can also return a simple pandas DataFrame without the complex MultiIndex. Just set `tidy = False`."
    ]
   },
   {
@@ -186,182 +167,469 @@
    },
    "outputs": [],
    "source": [
-    "cd.reset()\n",
-    "print(\"Interface reset - ready for new query\")"
+    "get_data_options(\n",
+    "    variable = \"precipitation\", \n",
+    "    timescale = \"daily\", \n",
+    "    tidy = False\n",
+    ") "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5501a518",
+   "id": "f3f954d4-7a75-4dcd-b6d6-8e7d730fc607",
    "metadata": {},
    "source": [
-    "## Retrieve data \n",
-    "The ClimateData interface allows you to chain method calls to build readable queries, and then retrieve the data easily in your query. \n",
-    "<br><br>\n",
-    "Required components of the query depend on the data catalog you're interested in. In general, the required components for all catalogs are: \n",
-    "- catalog \n",
-    "- variable "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "99bb1909",
-   "metadata": {},
-   "source": [
-    "### Example 1: Future air temperature data \n",
-    "You can retrieve data using a dictionary query, or by chaining operations to the ClimateData object. Either is valid and will result in the same output data, so just use whichever method is most intuitive to you. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5fd644bb",
-   "metadata": {},
-   "source": [
-    "#### Method 1: Dictionary query"
+    "## See all the geometry options for spatially subsetting the data during retrieval\n",
+    "These options will match those in our AE selections GUI. This will enable you to retrieve a subset for a specific region."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "029a6c60",
-   "metadata": {},
+   "id": "ddc1fdd4-8bc2-4785-ace1-229ba168d54f",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# Define your query \n",
-    "climate_query_dict = {\n",
-    "    \"catalog\": \"cadcat\", # Catalog name \n",
-    "    \"activity_id\": \"WRF\", # Downscaling method \n",
-    "    \"experiment_id\": \"ssp370\", # Simulation\n",
-    "    \"table_id\": \"mon\", # Temporal resolution \n",
-    "    \"grid_label\": \"d02\", # Grid resolution\n",
-    "    \"variable_id\": \"t2\" # Variable name \n",
-    "}\n",
-    "\n",
-    "# Load the query \n",
-    "climate_query = ClimateData().load_query(climate_query_dict)\n",
-    "\n",
-    "# Retrieve the data\n",
-    "climate_data = climate_query.get()"
+    "get_subsetting_options()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7d827595",
+   "id": "810fa239-8afb-4b20-b285-401fbaac40b4",
    "metadata": {},
    "source": [
-    "#### Method 2: Chained operations\n",
-    "\n",
-    "This will return the same data as above, but by chaining operations instead!"
+    "This shows a lot of options! Say you're only interested in California counties. Simply set the argument `area_subset` to \"CA counties\" to see the all options for counties. The function documentation shows the other options, which also match the values in the column \"area_subset\" in the table above. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2b4dfd3",
-   "metadata": {},
+   "id": "fb47d46e-1b5b-4105-bdad-e48aa50f93f0",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "cd.reset()\n",
-    "climate_data = (cd\n",
-    "    .catalog(\"cadcat\")\n",
-    "    .activity_id(\"WRF\")\n",
-    "    .experiment_id(\"ssp370\")\n",
-    "    .table_id(\"mon\")\n",
-    "    .grid_label(\"d02\")\n",
-    "    .variable(\"t2\")\n",
-    ").get()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e0be7d28",
-   "metadata": {},
-   "source": [
-    "### Example 2: Renewable energy model data \n",
-    "Note that the renewables catalog has an additional query option: `installation`. This indicates the energy generation method, a parameter that is only applicable for this particular catalog. "
+    "print(get_subsetting_options.__doc__)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc8436c6",
+   "id": "e5c602c6-d462-4474-b56e-cdd609394c33",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define your query \n",
-    "renewables_query_dict = {\n",
-    "    \"catalog\": \"renewable energy generation\", # Catalog name \n",
-    "    \"experiment_id\": \"historical\", # Model name \n",
-    "    \"table_id\": \"day\", # Temporal resolution \n",
-    "    \"grid_label\": \"d03\", # Grid resolution\n",
-    "    \"variable_id\": \"cf\", # Variable name \n",
-    "    \"installation\": \"pv_utility\", # Renewables catalog only! \n",
-    "    # \"source_id\": \"MPI-ESM1-2-HR\" # Optional: pick a simulation within the model \n",
-    "}\n",
-    "\n",
-    "# Load the query \n",
-    "renewables_query = ClimateData().load_query(renewables_query_dict)\n",
-    "\n",
-    "# Retrieve the data\n",
-    "renewables_data = renewables_query.get()"
+    "get_subsetting_options(area_subset = \"CA counties\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ec0937d9",
-   "metadata": {},
+   "id": "cd52eec3-afe7-4324-9c53-3861d39aafeb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-07-12T19:50:18.044997Z",
+     "iopub.status.busy": "2024-07-12T19:50:18.044611Z",
+     "iopub.status.idle": "2024-07-12T19:50:18.080969Z",
+     "shell.execute_reply": "2024-07-12T19:50:18.080035Z",
+     "shell.execute_reply.started": "2024-07-12T19:50:18.044969Z"
+    }
+   },
    "source": [
-    "## Working with Processors\n",
-    "You can further customize your data retrieval using `processors`, which perform operations on the data before it is returned to you. For example, two available processors are: \n",
-    "\n",
-    "- **`concat`** - Concatenate datasets along specified dimensions, default behavior is to concatenate on \"time\" using a historical+ssp approach.\n",
-    "- **`filter_unbiased_models`** - Remove or include unbiased models (default: \"yes\" to remove)\n",
-    "\n",
-    "These two processors are run by default every time that you retrieve data. Examples of other available processors can be found in the `climakitae` library documentation, or in other example notebooks. <br><br>\n",
-    "It's important to note that processors are applied as a **dictionary**. This enables you to add more than one processor to your chain of operations. "
+    "You can see all the options for subsetting, and their corresponding geometries, but you don't actually need to use the geometries for subsetting if you use climakitae's data retrieval function-- `get_catalog_data` -- explained in the next section. "
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "654ace5a",
+   "id": "103e4200-1c7f-49d8-a6e8-0e9602366f85",
    "metadata": {},
    "source": [
-    "### Example 3: Concatenation along a specified dimension\n",
-    "By default, when historical data is retrieved in the same operation as future data, the historical data will be appended to the future data, giving a single timeseries. However, you can change this default behavior by setting the query to concatenate along the simulation \"`sim`\" dimension instead. This will return the historical and future data as separate simulations. Concatenating by `time` or by `sim` have unique benefits, and you'll need to decide which method is most appropriate for your analyses. \n",
+    "## Retrieve data using the get_data() function\n",
+    "You can easily retrieve data from the Analytics Engine data catalog using climakitae's ```get_data``` function, described below. Additional details for each of the function arguments can be viewed in function docstrings in the next code cell. \n",
     "\n",
-    "In the returned data from the code below, future time periods for the historical simulation will be infilled with `NaN`, because the model has no data for that time period by definition. The same logic applies to the future simulations: any time in the past will be infilled with `NaN`. "
+    "### Required inputs \n",
+    "This function requires you to input values for the following arguments: \n",
+    "- variable (required)\n",
+    "- resolution (required)\n",
+    "- timescale (required)\n",
+    "\n",
+    "### Location subsetting \n",
+    "The options for location subsetting can be found using the `get_data_options()` function, as described in the beginning of this notebook. You can also opt to perform an area average by setting `area_average = \"Yes\"`. The `get_data()` function will default to returning the entire spatial domain, with no area averaging performed. \n",
+    "- area_subset (optional) \n",
+    "- cached_area (optional) \n",
+    "- area_average (optional)\n",
+    "\n",
+    "### Additional options\n",
+    "Further modify the data returned using the following arguments.\n",
+    "- downscaling method (optional)\n",
+    "- approach (optional) \n",
+    "- scenario (optional)\n",
+    "- units (optional)\n",
+    "- time_slice (optional)\n",
+    "- warming_level (optional)\n",
+    "- warming_level_window (optional)\n",
+    "- warming_level_months (optional)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d86b2725",
-   "metadata": {},
+   "id": "4d618321-6ecb-4656-8c9d-9d344d41b570",
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "concat_by_sim = (cd\n",
-    "    .catalog(\"cadcat\")\n",
-    "    .experiment_id([\"historical\", \"ssp370\"]) # Retrieve historical and future data \n",
-    "    .table_id(\"mon\")\n",
-    "    .grid_label(\"d01\")\n",
-    "    .variable(\"prec\") # Precipitation \n",
-    "    .processes({\n",
-    "        \"concat\": \"sim\"  # Concatenate along simulation dimension\n",
-    "    })\n",
-    "    .get()\n",
+    "# See additional details about the function arguments by printing the docstring\n",
+    "print(get_data.__doc__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "351a15bd-efb5-4376-9c90-8b58fe6cfbde",
+   "metadata": {},
+   "source": [
+    "### Example 1: Time-based approach\n",
+    "Retrieve gridded data using a time-based approach. ```approach``` is an optional function argument, but the default is to use a time-based approach, so you don't actually need to set this argument. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fdc1b79a-aede-4f8a-8162-492c6f3dfb8f",
+   "metadata": {},
+   "source": [
+    "#### Example 1a\n",
+    "First, let's retrieve 3 kilometer resolution statistically downscaled historical data at a monthly timestep. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b34cdd79-7854-4435-abcc-87258bd0a98b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Statistical\", \n",
+    "    resolution = \"3 km\", \n",
+    "    timescale = \"monthly\", \n",
+    "    scenario = \"Historical Climate\"\n",
+    "    # approach = \"Time\" # Optional because \"Time\" is the function default \n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "499b20f1",
+   "id": "17617637-59ff-4248-b1c1-f56f9f6b7391",
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2024-07-12T21:48:10.459519Z",
+     "iopub.status.idle": "2024-07-12T21:48:10.460048Z",
+     "shell.execute_reply": "2024-07-12T21:48:10.459831Z",
+     "shell.execute_reply.started": "2024-07-12T21:48:10.459807Z"
+    }
+   },
+   "source": [
+    "#### Example 1b\n",
+    "Now say you're only interested in this data for San Bernadino County, and you want to compute an area average over the entire county. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0c92a88-e9f9-41b4-b767-e2d07f5689b1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Statistical\", \n",
+    "    resolution = \"3 km\", \n",
+    "    timescale = \"monthly\", \n",
+    "    scenario = \"Historical Climate\",\n",
+    "    \n",
+    "    # Modify location settings\n",
+    "    cached_area = \"San Bernardino County\", \n",
+    "    area_average = \"Yes\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf03d13f-12bc-4a36-9a74-067d3e22427d",
    "metadata": {},
    "source": [
-    "## Exporting data  \n",
-    "To save data as a file, call export and input your desired: \n",
-    "1. data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html) (this is the default data type returned by `ClimateData.get()`)\n",
-    "2. output file name (without file extension)\n",
-    "3. file format (\"NetCDF\", \"Zarr\", or \"CSV\")\n",
+    "#### Example 1c \n",
+    "Perhaps next you want to get dynamically downscaled (i.e. WRF) precipitation data instead. First, you might want to check what options you have for scenario, timescale, and resolution using the ```get_data_options()``` function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c44761d0-3058-44ef-9da8-4ec70ff47dfb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data_options(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Dynamical\"\n",
+    ") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ce558ae-c3ed-417b-a3b2-b0b67e73d8e8",
+   "metadata": {},
+   "source": [
+    "Next, let's retrieve both the future and historical dynamically downscaled data. \"Historical Climate\" is the correct historical data option here; \"Historical Reconstruction\" data is from ERA5 (a climate reanalysis product, rather than a climate model), and cannot be retrieved with future data in the same function call. <br><br>You can set the ```scenario``` argument to retrieve the shared socioeconomic pathway data (future projections) appended to the historical data. You can also set your desired time period using the ```time_slice``` argument. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0125fd6b-968e-4332-aa8a-99a25728d364",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Dynamical\", \n",
+    "    resolution = \"45 km\", \n",
+    "    timescale = \"monthly\", \n",
+    "    cached_area = \"San Bernardino County\", \n",
+    "    \n",
+    "    # Modify time-based settings \n",
+    "    time_slice = (2000,2050),\n",
+    "    scenario = [\n",
+    "        \"Historical Climate\", \n",
+    "        \"SSP 3-7.0\", \n",
+    "        \"SSP 2-4.5\",\n",
+    "        \"SSP 5-8.5\"\n",
+    "    ]\n",
+    ") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a80061c2-4f72-4e93-a93a-e7b7a9cddec4",
+   "metadata": {},
+   "source": [
+    "### Example 2: Warming levels approach \n",
+    "By default, the function uses a time-based approach. To use a warming levels approach, set the argument ```approach = \"Warming Level\"```. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "299fd264-7914-40b7-8f5a-388c336c2734",
+   "metadata": {},
+   "source": [
+    "#### Example 2a\n",
+    "Retrieve the same data as example 1c, using a warming levels approach instead of a time-based approach. Note that the ```scenario``` and ```time_slice``` arguments are invalid for a warming levels approach; if provided, they will be ignored by the function. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41f10134-da0a-469d-b07b-9c4237c83528",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Dynamical\", \n",
+    "    resolution = \"45 km\", \n",
+    "    timescale = \"monthly\", \n",
+    "    cached_area = \"San Bernardino County\", \n",
+    "    \n",
+    "    # Modify your approach \n",
+    "    approach = \"Warming Level\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "405d2a80-8edf-476a-869f-410e7952035a",
+   "metadata": {},
+   "source": [
+    "#### Example 2b\n",
+    "The ```get_data()``` function uses a default warming levels window of +/- 15 years, resulting in a 30 year period. Lets modify that by setting ```warming_level_window = 10``` to retrieve a 20 year window.<br><br>We can also modify the warming levels computed to include additional warming levels beyond the default. Let's select a few more by setting ```warming_level = [2.5, 3.0, 4.0]```. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e733eeb2-159c-4a58-bbdb-7a72e3669be8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Precipitation (total)\", \n",
+    "    downscaling_method = \"Dynamical\", \n",
+    "    resolution = \"45 km\", \n",
+    "    timescale = \"monthly\", \n",
+    "    cached_area = \"San Bernardino County\", \n",
+    "    approach = \"Warming Level\",\n",
+    "    \n",
+    "    # Modify warming level settings \n",
+    "    warming_level_window = 10, \n",
+    "    warming_level = [2.5, 3.0, 4.0]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "494f85e5-f34f-449b-a7fe-224641d79d7c",
+   "metadata": {},
+   "source": [
+    "### Example 3: Weather station data \n",
+    "By default, the function retrieves non-bias-corrected gridded data, but you can also retrieve dynamically downscaled climate data that has been bias-corrected using historical weather station data. This data is retrieved at the unique grid cell(s) corresponding to the selected weather station(s). This data can be retrieved using the `data_type` and `stations` arguments. If you don't set the `stations` argument, the function will return all available weather stations-- a hefty data retrieval that takes a while to run and is therefore is not recommended. \n",
+    "\n",
+    "```\n",
+    "data_type = \"Stations\" # Return bias-corrected gridded data at a station(s) of interest \n",
+    "data_type = \"Gridded\" # Return gridded data (function default) \n",
+    "```\n",
+    "\n",
+    "As of now, you can only retrieve hourly data for the variable \"Air Temperature at 2m\". You can also choose the resolution of the gridded data used in bias correction by setting the `resolution` argument to either \"3 km\" or \"9 km\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54c38e1c-a6ed-47b2-bbc7-8e0eb9ed7bb2",
+   "metadata": {},
+   "source": [
+    "#### Example 3a"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcc80cdf-1492-4abd-b05b-e075636ee2e3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Air Temperature at 2m\", # Required argument\n",
+    "    resolution = \"9 km\", # Required argument. Options: \"9 km\" or \"3 km\" \n",
+    "    timescale = \"hourly\", # Required argument\n",
+    "    data_type = \"Stations\", # Required argument\n",
+    "    stations = \"San Diego Lindbergh Field (KSAN)\" # Optional argument. If no input, all weather stations are retrieved \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "377ae925-c9b8-4939-9849-c7933edc9c54",
+   "metadata": {},
+   "source": [
+    "To see all the available weather station options, you can use the `get_subsetting_options()` function detailed at the top of this notebook. Simply set the `area_subset` function argument to `\"Stations\"`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9797d13c-b7b6-4939-9e17-e621e970d251",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_subsetting_options(area_subset=\"Stations\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "848ce0b1-348d-439e-9e85-c14660302061",
+   "metadata": {},
+   "source": [
+    "#### Example 3b\n",
+    "To demonstrate the flexibility of this function, let's make a few changes to the function argument in the code below: \n",
+    "1) Retrieve more than one weather station. \n",
+    "2) Change the resolution of the data used for bias-correction\n",
+    "3) Change the variable units (function default to degrees Kelvin, the native unit of the raw data)\n",
+    "4) Change the timescale to retrieve a 5 year period (function defaults to the entire historical record: 1980-2014)\n",
+    "\n",
+    "Note that this function will take more time to run since we're retrieving more than one station. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "366f71c2-b168-4ccd-89a1-f25355a7b9bc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Air Temperature at 2m\", \n",
+    "    resolution = \"3 km\",\n",
+    "    timescale = \"hourly\",\n",
+    "    data_type = \"Stations\",\n",
+    "    stations = [\n",
+    "        \"San Francisco International Airport (KSFO)\", \n",
+    "        \"Oakland Metro International Airport (KOAK)\", \n",
+    "    ],\n",
+    "    units = \"degF\", \n",
+    "    time_slice = (2000,2005) \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6ee393a",
+   "metadata": {},
+   "source": [
+    "#### Example 3c \n",
+    "You can also retrieve data for the future period by setting the `scenario` argument to one or more SSPs. The code below will retrieve data for 2000-2035 for the Sacramento Executive Airport (KSAC) station under Shared Socioeconomic Pathway 3-7.0. Since we are retrieving data in both the historical and future period, we need to set the scenario to `['Historical Climate', 'SSP 3-7.0']`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11aa4359",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_data(\n",
+    "    variable = \"Air Temperature at 2m\", \n",
+    "    resolution = \"9 km\",\n",
+    "    timescale = \"hourly\",\n",
+    "    data_type = \"Stations\",\n",
+    "    stations = \"Sacramento Executive Airport (KSAC)\",\n",
+    "    units = \"degF\", \n",
+    "    time_slice = (2000,2035),\n",
+    "    scenario = [\"Historical Climate\", \"SSP 3-7.0\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4bb1dc13",
+   "metadata": {},
+   "source": [
+    "## Exporting data\n",
+    "\n",
+    "To save data as a file, call `export` and input your desired\n",
+    "1) data to export – an [xarray DataArray or Dataset](https://docs.xarray.dev/en/stable/user-guide/data-structures.html), as output by e.g. selections.retrieve()\n",
+    "2) output file name (without file extension)\n",
+    "3) file format (\"NetCDF\", \"Zarr\", or \"CSV\")\n",
     "\n",
     "We recommend NetCDF or Zarr, which suits data and outputs from the Analytics Engine well – they efficiently store large data containing multiple variables and dimensions. Metadata will be retained in these files.\n",
     "\n",
@@ -375,27 +643,68 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ecf6e5cc",
+   "id": "b667b27f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Download a subset of the data from example 3 \n",
-    "data_to_export = concat_by_sim.sel(time=slice(\"2023\", \"2025\")) # Just grab a few years of data (2023-2025)\n",
-    "ck.export(data_to_export, filename=\"my_filename2\", format=\"NetCDF\") "
+    "# First, load some data into an xarray object using get_data \n",
+    "data_to_download = get_data(\n",
+    "    variable = \"Air Temperature at 2m\", \n",
+    "    downscaling_method = \"Dynamical\", \n",
+    "    resolution = \"45 km\", \n",
+    "    timescale = \"monthly\", \n",
+    "    scenario = \"Historical Climate\",\n",
+    "    time_slice = (2000,2001)\n",
+    ")\n",
+    "\n",
+    "# Next, export the data to a netcdf file \n",
+    "ck.export(data_to_download, filename=\"my_filename1\", format=\"NetCDF\") "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32306bec",
+   "metadata": {},
+   "source": [
+    "Some additional file export formats are demonstrated below. The code has been commented out; simply remove the code comment hash (#) at beginning of the line to make the code executable. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11395e4d",
+   "id": "47856284",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# ck.export(data_to_use, filename=\"my_filename2\", format=\"Zarr\") # Zarr export locally\n",
+    "\n",
+    "# ck.export(data_to_use, filename=\"my_filename3\", format=\"Zarr\", mode=\"s3\") # Zarr export to S3\n",
+    "\n",
+    "# ck.export(data_to_use, filename=\"my_filename4\", format=\"CSV\") # CSV export locally"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04611092",
+   "metadata": {},
+   "source": [
+    "Zarr format is technically a directory, not a single file, because it uses chunking to write and read data. This cloud-optimized format enables some unique benefits for performing data computations in a cloud computing environment like the AE Jupyter Hub, but can also make it tricky to delete. Because of that, we have built a simple helper function to facilitate easily deleting zarrs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a28e241e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ck.remove_zarr(\"my_filename2\") # Helper function to delete Zarr directory tree"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "climakitae",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -409,7 +718,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Reverts cal-adapt/cae-notebooks#190

We don't have any examples of warming level use with `get_data` outside of `basic_data_access` meaning this merge removed all public examples of how to fetch data using a warming level approach with `get_data`. 

This merge is being reverted until new_core maintains all current functionality of `get_data`