### PR TITLE
adding custom 1-in-x notebook

### DIFF
--- a/work-in-progress/custom_1_in_x.ipynb
+++ b/work-in-progress/custom_1_in_x.ipynb
@@ -18,8 +18,8 @@
     "2. Designing my own custom metric\n",
     "\n",
     "> [!WARNING]\n",
-    "> - **Thread Safety**: `DataInterface` does not play nicely with multi-threading. If you want to multi-thread your calls to `get_data()`, please use code cell 2 to monkey patch the `__init__()` method.\n",
-    "> - This notebook is optimized for speed over precision. Bootstrap samples are set to 0, which means confidence intervals are not representative. Increase `bootstrap_runs` in `_process_one_simulation()` for accurate confidence intervals.\n",
+    "> - **Thread Safety**: `DataInterface` was not originally intended for multi-threading. This has been patched in `climakitae` versions above v1.4.0. Please ensure you are using the latest version.\n",
+    "> - This notebook is optimized for speed over precision. Bootstrap samples are set to 1, which means confidence intervals are not representative. Increase `bootstrap_runs` in `_process_one_simulation()` for accurate confidence intervals.\n",
     "\n",
     "> [!NOTE]\n",
     "> With the default settings, this notebook will take **4+ hours per worker** to run from start to finish. Modifications may increase the runtime. On a JupyterHub machine with 30 GB RAM, there is a maximum of 4-5 workers since each worker uses ~5 GB. In testing, each worker took 3.5 hours to finish a batch of **50 locations**. When selecting your batch size, be aware of the potential runtime. "
@@ -75,77 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "VERBOSE = True \n",
-    "\n",
-    "# Verify everything loaded correctly\n",
-    "if VERBOSE:\n",
-    "    print(\"✓ DataInterface initialized successfully!\")\n",
-    "    print(f\"  Data catalog loaded: {len(data_interface.data_catalog.df)} entries\")\n",
-    "    print(f\"  Variable descriptions loaded: {len(data_interface.variable_descriptions)} variables\")\n",
-    "    print(f\"  Stations loaded: {len(data_interface.stations)} stations\")\n",
-    "    print(f\"  Boundaries loaded:\")\n",
-    "    print(f\"    - US States: {len(data_interface.geographies._us_states)} states\")\n",
-    "    print(f\"    - CA Counties: {len(data_interface.geographies._ca_counties)} counties\")\n",
-    "    print(f\"    - CA Watersheds: {len(data_interface.geographies._ca_watersheds)} watersheds\")\n",
-    "    print(f\"    - CA Utilities: {len(data_interface.geographies._ca_utilities)} utilities\")\n",
-    "    print()\n",
-    "    print(\"🎉 Now safe to use multi-threading with get_data()!\")\n",
-    "    print(\"=\"*60)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "1a156787",
-   "metadata": {},
-   "source": [
-    "#### Step 1: Monkey Patch `DataInterface.__init__` for Thread Safety\n",
-    "\n",
-    "When running parallel batch processing (e.g., with `ThreadPoolExecutor`), multiple threads may attempt to instantiate the `DataInterface` at the same time. The original `__init__` method is not thread-safe and can lead to race conditions, causing errors or inconsistent state if two threads initialize it simultaneously.\n",
-    "\n",
-    "**Monkey patching** the `__init__` method with a thread lock ensures that initialization occurs only once, regardless of how many threads attempt to create a `DataInterface` instance. This guarantees safe, predictable behavior in multi-threaded workflows and prevents issues such as duplicate resource loading or partial initialization.\n",
-    "\n",
-    "This fix applies to all instances of attempting to parallelize data access calls in `climakitae`. The following cell should be included in any instance where data access needs to be multi-threaded including: `cava_data()`, `get_data()`, `DataParameters.retrieve()`, etc."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f2defb9e-0b79-40a4-b8bc-cee3505de048",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ADVANCED: Monkey-patch to prevent re-initialization\n",
-    "# Only use this if kernel restart + STEP 1 doesn't work\n",
-    "import threading\n",
-    "\n",
-    "# Save the original __init__\n",
-    "_original_init = DataInterface.__init__\n",
-    "\n",
-    "# Create a lock for thread safety\n",
-    "_init_lock = threading.Lock()\n",
-    "_initialized = False\n",
-    "\n",
-    "def _patched_init(self, **params):\n",
-    "    \"\"\"Patched __init__ that only runs once.\"\"\"\n",
-    "    global _initialized\n",
-    "    \n",
-    "    with _init_lock:\n",
-    "        if _initialized:\n",
-    "            # Already initialized, skip\n",
-    "            return\n",
-    "        \n",
-    "        # First time - run original init\n",
-    "        _original_init(self, **params)\n",
-    "        _initialized = True\n",
-    "        print(\"✓ DataInterface initialized (first time only)\")\n",
-    "\n",
-    "# Apply the patch\n",
-    "DataInterface.__init__ = _patched_init\n",
-    "\n",
-    "if VERBOSE:\n",
-    "    print(\"✓ Monkey-patch applied - DataInterface will only initialize once\")\n",
-    "    print(\"Now run STEP 1 to initialize it:\")\n",
-    "    print(\"=\"*60)"
+    "VERBOSE = True "
    ]
   },
   {
@@ -153,7 +83,7 @@
    "id": "2270beff",
    "metadata": {},
    "source": [
-    "#### Step 2: Custom Metric Definition\n",
+    "#### Step 1: Custom Metric Definition\n",
     "\n",
     "As an example, we will build a customized version of effective temperature (T<sub>eff</sub>) metric, as many utilities may use different thresholds. Effective temperature is calculated using a weighted combination of current and lagged temperature values. \n",
     "```\n",
@@ -225,7 +155,7 @@
    "id": "29b6e683",
    "metadata": {},
    "source": [
-    "#### Step 3: Set-up the 1-in-X Custom Calculation Functions\n",
+    "#### Step 2: Set-up the 1-in-X Custom Calculation Functions\n",
     "\n",
     "Now we'll set-up the core processing for calculating 1-in-X year return values for custom climate metrics. The `calculate_1_in_x_custom()` function calculates 1-in-X year return values (e.g., 1-in-10 year, 1-in-100 year events) for custom climate metrics using extreme value analysis. It processes multiple locations and climate model simulations efficiently in batch mode. `calculate_1_in_x_custom()` has a **5-step process**: (**1**) validation and set-up, (**2**) spatial data extraction, (**3**) data preparation, (**4**) simulation processing for computing return values, and (**5**) optimized output. This 5-step process ensures that batch-processing is efficient and minimizes memory usage as is feasible. The `_process_one_simulation()` internal helper function processes a single climate simulation (or simulation-warming_level combination) to calculate return values and goodness-of-fit statistics, ensuring multi-simulation processing efficiency.\n",
     "\n",
@@ -876,7 +806,7 @@
    "id": "c83e0c8d",
    "metadata": {},
    "source": [
-    "#### Step 4: Calculate 1-in-X Events for Effective Temperature\n",
+    "#### Step 3: Calculate 1-in-X Events for Effective Temperature\n",
     "\n",
     "First, we'll set-up a number of useful arguments, including *location*, *data variable retrieval*, *1-in-X approach return periods*, and *batch size*. "
    ]
@@ -1241,14 +1171,6 @@
     "\n",
     "Without multi-threading, a batch size of **1600 locations** would take approximately **27 days to complete**. With multi-threading, the same batch size completes in **28 hours**.  "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cf72bcfe-4e90-48dd-ad82-41a04dc1f320",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary of changes and related issue
Added a notebook that allows users to calculate return values (1-in-X) for a custom metric or dataset.

## Relevant motivation and context
Several IOUs have requested something similar. This represents our efforts to provide necessary tooling without having to build custom metrics directly into `climakitae`.

## Type of Change

- [ ] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
