### PR TITLE
206 bug agnostic gets called in finder notebooks

### DIFF
--- a/work-in-progress/climate_state_finder.ipynb
+++ b/work-in-progress/climate_state_finder.ipynb
@@ -85,10 +85,13 @@
     "# display variables available for this analysis \n",
     "# only showing dynamical because statistical has a smaller subset that is in the larger dynamical subset\n",
     "# only difference is max/min RH is available in statistical and not in dynamical \n",
-    "get_data_options(\n",
+    "variables = get_data_options(\n",
     "    downscaling_method=\"Dynamical\", \n",
     "    timescale=timescale\n",
-    ")"
+    ")['variable'].reset_index(drop=True).unique()\n",
+    "\n",
+    "for var in variables:\n",
+    "    print(var)"
    ]
   },
   {

--- a/work-in-progress/event_finder.ipynb
+++ b/work-in-progress/event_finder.ipynb
@@ -95,10 +95,13 @@
     "# display variables available for this analysis\n",
     "# only showing dynamical because statistical has a smaller subset that is in the larger dynamical subset\n",
     "# only difference is max/min RH is available in statistical and not in dynamical\n",
-    "get_data_options(\n",
+    "variables = get_data_options(\n",
     "    downscaling_method=\"Dynamical\", \n",
     "    timescale=timescale\n",
-    "    )"
+    ")['variable'].reset_index(drop=True).unique()\n",
+    "\n",
+    "for var in variables:\n",
+    "    print(var)"
    ]
   },
   {


### PR DESCRIPTION
## Summary of changes and related issue
Removing dependency on agnostic tools from Finder notebooks

## Relevant motivation and context
notebooks were broken because they had a dependency on a variable display function from agnostic, and agnostic has been remove.

## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
