### PR TITLE
fixing holoview backend issue

### DIFF
--- a/analysis/internal_variability.ipynb
+++ b/analysis/internal_variability.ipynb
@@ -87,6 +87,7 @@
     "from climakitae.util.colormap import read_ae_colormap\n",
     "\n",
     "import holoviews as hv\n",
+    "hv.extension('bokeh')  # Load the bokeh backend for HoloViews\n",
     "from bokeh.models import HoverTool\n",
     "import xarray as xr\n",
     "import numpy as np\n",


### PR DESCRIPTION
## Summary of changes and related issue
Added 'bokeh' as backend engine for HoloViews

## Relevant motivation and context
Fixing the notebook so that it runs again

Cell 6 runs again and outputs the following plots

<img width="1057" height="784" alt="Screenshot from 2025-12-03 09-39-25" src="https://github.com/user-attachments/assets/d04bc8e0-2183-4419-bb29-41531dbb159e" />
<img width="1057" height="784" alt="Screenshot from 2025-12-03 09-39-22" src="https://github.com/user-attachments/assets/7e1d4f84-b7de-495d-a640-f7549c9a9790" />
<img width="1057" height="784" alt="Screenshot from 2025-12-03 09-39-19" src="https://github.com/user-attachments/assets/1c9bfe6c-48de-4962-861d-cc2e4d5dd2f9" />


## Type of Change

- [x] Bug fix
- [ ] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [x] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
