### PR TITLE
Update event finder to use new core

### DIFF
--- a/data-access/basic_data_access.ipynb
+++ b/data-access/basic_data_access.ipynb
@@ -1407,7 +1407,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (climakitae)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1421,7 +1421,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary of changes and related issue

- Use new core to see options and pull data
- Add lat/lon box and cached area as domain options

Relies on changes in branches in climakitae:
- features/add-sum-to-metric-calc

## Relevant motivation and context
`get_data` will be deprecated so upgrading to new core is necessary. Adding additional spatial domain options gives users more flexibility and allows the notebook to be run out-of-the-box without the user providing their own shapefile.

## Type of Change

- [ ] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [ ] Incorporates reference to any appropriate Guidance material
- [x] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
