### PR TITLE
Event finder can use timeseries from file

### DIFF
--- a/work-in-progress/event_finder.ipynb
+++ b/work-in-progress/event_finder.ipynb
@@ -714,7 +714,7 @@
     "if event_variable_loca2 is not UNSET:\n",
     "    if loca2_filename is not UNSET:\n",
     "        loca_data = xr.open_dataset(loca2_filename)\n",
-    "        loca_data = wrf_data.sel(warming_level=future_gwl)\n",
+    "        loca_data = loca_data.sel(warming_level=future_gwl)\n",
     "    else:\n",
     "        # grab correct variable name for LOCA2\n",
     "        loca_variable = [event_variable_loca2]\n",


### PR DESCRIPTION
## Summary of changes and related issue
Additional capability added for the event finder to skip loading data from cadcat and instead read a timeseries from file.

## Relevant motivation and context
This functionality is needed to support the Santa Ana winds metrics. The input data will be 2-point differences generated in a different notebook, which can then be input into the event finder.

## How to test
I've got a sample timeseries file on Google Drive, will share in Slack.

## Type of Change

- [ ] Bug fix
- [x] New feature or notebook
- [ ] Breaking change
- [ ] Documentation update
- [ ] None of the above

## Checklist
- [x] The introduction of the notebook explains the purpose and expected outcome / use of the notebook
- [x] Incorporates reference to any appropriate Guidance material
- [ ] Notebook raises appropriate error messages for common user errors
- [x] List notebook overall runtime text
- [ ] [AE navigation guide](https://github.com/cal-adapt/cae-notebooks/blob/main/AE_navigation_guide.ipynb) updated (if relevant)
