### PR TITLE
Improve folium map in HDP data access notebook 

### DIFF
--- a/data-access/weather_station_data_access.ipynb
+++ b/data-access/weather_station_data_access.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import intake \n",
+    "import intake\n",
     "import pandas as pd\n",
     "import geopandas as gpd\n",
     "import matplotlib.pyplot as plt"
@@ -42,7 +42,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = intake.open_esm_datastore(\"https://cadcat.s3.amazonaws.com/histwxstns/era-hdp-collection.json\")"
+    "cat = intake.open_esm_datastore(\n",
+    "    \"https://cadcat.s3.amazonaws.com/histwxstns/era-hdp-collection.json\"\n",
+    ")"
    ]
   },
   {
@@ -80,7 +82,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# See all network options \n",
+    "# See all network options\n",
     "cat_df[\"network_id\"].unique()"
    ]
   },
@@ -118,13 +120,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set your query here \n",
+    "# Set your query here\n",
     "query = {\n",
     "    \"network_id\": \"ASOSAWOS\",  # Name of the network\n",
-    "    \"station_id\": [\"ASOSAWOS_72288023152\",\"ASOSAWOS_72389093193\",\"ASOSAWOS_72297603166\",\"ASOSAWOS_72493023230\"] # List of stations to get data for \n",
+    "    \"station_id\": [\n",
+    "        \"ASOSAWOS_72288023152\",\n",
+    "        \"ASOSAWOS_72389093193\",\n",
+    "        \"ASOSAWOS_72297603166\",\n",
+    "        \"ASOSAWOS_72493023230\",\n",
+    "    ],  # List of stations to get data for\n",
     "}\n",
     "\n",
-    "# Subset catalog \n",
+    "# Subset catalog\n",
     "cat_subset = cat.search(**query)\n",
     "\n",
     "# View the data you've selected before downloading\n",
@@ -146,10 +153,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get dataset dictionary \n",
+    "# Get dataset dictionary\n",
     "dsets = cat_subset.to_dataset_dict(\n",
-    "    xarray_open_kwargs={'consolidated':False},\n",
-    "    storage_options={'anon':True}\n",
+    "    xarray_open_kwargs={\"consolidated\": False}, storage_options={\"anon\": True}\n",
     ")"
    ]
   },
@@ -237,10 +243,14 @@
    "outputs": [],
    "source": [
     "# Read in the Historical Data Platform station list\n",
-    "hdp_stns = pd.read_csv(\"https://cadcat.s3.amazonaws.com/histwxstns/historical_wx_stations.csv\")\n",
+    "hdp_stns = pd.read_csv(\n",
+    "    \"https://cadcat.s3.amazonaws.com/histwxstns/historical_wx_stations.csv\"\n",
+    ")\n",
     "\n",
     "# Convert to a GeoDataFrame so we can use the geometry column for subsetting\n",
-    "hdp_stns = gpd.GeoDataFrame(hdp_stns, geometry=gpd.GeoSeries.from_wkt(hdp_stns[\"geometry\"]), crs=\"EPSG:4326\")"
+    "hdp_stns = gpd.GeoDataFrame(\n",
+    "    hdp_stns, geometry=gpd.GeoSeries.from_wkt(hdp_stns[\"geometry\"]), crs=\"EPSG:4326\"\n",
+    ")"
    ]
   },
   {
@@ -259,13 +269,15 @@
    "outputs": [],
    "source": [
     "# Region of Interest shapefile\n",
-    "roi = gpd.read_file(\"https://geo.sandag.org/server/rest/directories/downloads/Fire_Burn_History_shapefile.zip\") # Replace this with your own shapefile!\n",
+    "roi = gpd.read_file(\n",
+    "    \"https://geo.sandag.org/server/rest/directories/downloads/Fire_Burn_History_shapefile.zip\"\n",
+    ")  # Replace this with your own shapefile!\n",
     "\n",
     "# Convert to projection of HDP data\n",
-    "roi = roi.to_crs(hdp_stns.crs) \n",
+    "roi = roi.to_crs(hdp_stns.crs)\n",
     "\n",
-    "# Subset the shapefile to just get the Cedar fire of 2003 \n",
-    "cedar_fire_2003 = roi[(roi[\"FIRE_NAME\"]==\"CEDAR\") & (roi[\"YEAR_\"] == 2003)]\n",
+    "# Subset the shapefile to just get the Cedar fire of 2003\n",
+    "cedar_fire_2003 = roi[(roi[\"FIRE_NAME\"] == \"CEDAR\") & (roi[\"YEAR_\"] == 2003)]\n",
     "cedar_fire_2003"
    ]
   },
@@ -277,7 +289,9 @@
    "outputs": [],
    "source": [
     "# Clip the stationlist to subset within your area of interest\n",
-    "stns_within_area = gpd.sjoin(hdp_stns, cedar_fire_2003, how='inner', predicate='intersects').reset_index(drop=True)"
+    "stns_within_area = gpd.sjoin(\n",
+    "    hdp_stns, cedar_fire_2003, how=\"inner\", predicate=\"intersects\"\n",
+    ").reset_index(drop=True)"
    ]
   },
   {
@@ -314,9 +328,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(8,10))\n",
-    "cedar_fire_2003.plot(ax=ax, color='rosybrown')\n",
-    "stns_within_area.plot(ax=ax, color='darkblue', markersize=12, label=\"station\")\n",
+    "fig, ax = plt.subplots(figsize=(8, 10))\n",
+    "cedar_fire_2003.plot(ax=ax, color=\"rosybrown\")\n",
+    "stns_within_area.plot(ax=ax, color=\"darkblue\", markersize=12, label=\"station\")\n",
     "ax.legend()\n",
     "ax.set_title(\"Weather stations within the Cedar Fire boundary\");"
    ]
@@ -326,7 +340,7 @@
    "id": "16e7664d-cc10-4762-8205-d12371e6b626",
    "metadata": {},
    "source": [
-    "Want a more interactive way to view the data? Use `stns.explore()`, a geopandas method that will generate an interactive map where you can zoom, pan, and click features to see their attributes. Note, this map may take some time to load. "
+    "Want a more interactive way to view the data? Use `.explore()`, a geopandas method that will generate an interactive map where you can zoom, pan, and click features to see their attributes."
    ]
   },
   {
@@ -338,9 +352,11 @@
    "source": [
     "points = stns_within_area.explore(\n",
     "    tooltip=[\"era-id\", \"network\", \"latitude\", \"longitude\", \"elevation\", \"total_nobs\"],\n",
-    "    marker_kwds={\"radius\": 4}\n",
+    "    marker_kwds={\"radius\": 4},\n",
     ")\n",
-    "cedar_fire_2003.explore(m=points, style_kwds={\"fill\": False, \"color\": \"red\", \"weight\": 2})"
+    "cedar_fire_2003.explore(\n",
+    "    m=points, style_kwds={\"fill\": False, \"color\": \"red\", \"weight\": 2}\n",
+    ")"
    ]
   }
  ],


### PR DESCRIPTION
## Summary of changes (NEW) 
`folium` and `mapclassify` will be added to the Hub environment. Folium map in notebook was improved. 

## Summary of changes (OLD) 
Remove folium map section in HDP data access notebook due to environment issues. 

Our environment must have changed since I developed this notebook, and folium is now no longer in our Hub environment nor is it a `climakitae` dependency. I think better just to delete the section with the folium map rather than add this additional heavy dependency. It must have been installed as a sub-dependency of some other package we no longer support. 

## Link to corresponding Jira ticket(s)
Jira: https://eaglerockanalytics.atlassian.net/browse/AE-1272
Related GitHub Issue: https://github.com/cal-adapt/cae-notebooks/issues/222