### PR TITLE
Refactor Heat Index Notebook

### DIFF
--- a/collaborative/IOU/calculate_heat_index.ipynb
+++ b/collaborative/IOU/calculate_heat_index.ipynb
@@ -963,14 +963,6 @@
    "source": [
     "ck.export(heatidx_hist_hour, f\"heat_index_historical_{station_name}\", \"netcdf\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ca38e10e-2f9f-45fc-9ddb-544853a4fc85",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary of changes

- Use new core
- Use new core to clip station and convert to local time (new processor)
- Update OSHA heat index thresholds.

Question: should we rename the notebook to something like "calculate_heat_index.ipynb" to add action+objective or keep existing name the same?

Notes:
Results will not exactly match the original heat index notebook. Some models are excluded by default in new core and I've left it that way. Additionally, the heat index calculation is a little different in new core than in the tools/indices.py version.

Test with climakitae branch feature/convert-to-local-time-proc

## Link to corresponding Jira ticket(s)
[AE-1235](https://eaglerockanalytics.atlassian.net/browse/AE-1235?atlOrigin=eyJpIjoiNWM4ODM3YjFlYzllNDZlNzg3ZmExNGM0YjU3ZjEzODAiLCJwIjoiaiJ9)

## Naming & Organization
- [x] Notebook name follows conventions:
  - [x] Avoids acronyms and jargon where possible
  - [x] References primary use of the notebook
  - [x] Uses Action + Objective format (e.g., "calculate_heat_index", "calculate_annual_trends")
  - [x] Prioritizes clarity over brevity (within reason)
- [x] Notebook placed in appropriate directory for maximum usability

## Content & Documentation
- [x] Introduction clearly explains the purpose of the analysis
- [x] Intended application of the notebook listed
  - User-focused question/example provided showing how a user may want to use the notebook
- [x] Incorporates references to appropriate Guidance materials
- [x] Error messages included for areas with common user errors

## Runtime Information
- [x] Overall runtime on AE JupyterHub documented

## Output Management
- [x] Output from cells removed before committing

## Code Quality
- [x] Notebook cleaned up with:
  - [x] black
  - [x] isort
