### PR TITLE
Bugfix for Santa Ana windrose

### DIFF
--- a/work-in-progress/compute_santa_ana_wind_indicators.ipynb
+++ b/work-in-progress/compute_santa_ana_wind_indicators.ipynb
@@ -55,7 +55,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install h5netcdf\n",
     "!pip install windrose"
    ]
   },
@@ -571,12 +570,12 @@
     "        ax.set_yticks(ticks)\n",
     "        ax.set_yticklabels([f\"{p}%\" for p in ticks])\n",
     "\n",
-    "        plt.show()\n",
-    "\n",
     "        plt.tight_layout()\n",
+    "        plt.show()\n",
     "        fig.savefig(\n",
     "            f\"wind_rose_point_{point_ind}_{plot_level}hPa_{str(plot_gwl).replace('.','pt')}.png\"\n",
-    "        )"
+    "        )\n",
+    "        plt.close(fig)"
    ]
   },
   {
@@ -769,9 +768,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fs = s3fs.S3FileSystem(anon=True)\n",
     "elevation_url = \"s3://cadcat/wrf/cae/elevation_wrf.nc\"\n",
-    "elevation = xr.open_dataset(fs.open(elevation_url), engine=\"h5netcdf\")"
+    "elevation = xr.open_dataset(\n",
+    "    elevation_url, engine=\"h5netcdf\", storage_options={\"anon\": True}\n",
+    ")"
    ]
   },
   {
@@ -849,14 +849,6 @@
     "plt.tight_layout()\n",
     "plt.savefig(f\"slp_gradient_by_gwl_{plot_sim}.png\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5b2e6729-76f4-4fdd-bd4f-8c5cf607f1cb",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary of changes
The Santa Ana windrose is currently combining all warming levels in each figures. I want to only plot one warming level at a time.

Only the fourth cell in "3. Wind on Pressure Levels" has been changed and needs to be tested. I've uploaded test files [here](https://drive.google.com/drive/u/0/folders/1XvhhotyKP0TzheSFXrETUOxv-cYvs4Ev). Move these files to the work-in-progress directory, run all the cells in the "Setup" section, then run cell 4 in section 3. Check that the figures change if the warming level (`plot_gwl`) is changed.
The options for `plot_level` in the test data are any of [850., 700., 500., 300., 200.]
The options for`plot_gwl` are `future_gwl` or `baseline_gwl` or any of [0.8, 1.5]


## Link to corresponding Jira ticket(s)
[AE-1106](https://eaglerockanalytics.atlassian.net/browse/AE-1106)

## Naming & Organization
- [x] Notebook name follows conventions:
  - [x] Avoids acronyms and jargon where possible
  - [x] References primary use of the notebook
  - [x] Uses Action + Objective format (e.g., "calculate_heat_index", "calculate_annual_trends")
  - [x] Prioritizes clarity over brevity (within reason)
- [x] Notebook placed in appropriate directory for maximum usability
- [x] All referenced guides/documentation updated:
  - [x] README updated
  - [x] Navigation Guide updated

## Content & Documentation
- [x] Introduction clearly explains the purpose of the analysis
- [x] Intended application of the notebook listed
  - User-focused question/example provided showing how a user may want to use the notebook
- [x] Incorporates references to appropriate Guidance materials
- [x] Error messages included for areas with common user errors

## Runtime Information
- [x] Overall runtime on AE JupyterHub documented

## Output Management
- [x] Output from cells removed before committing

## Code Quality
- [x] Notebook cleaned up with:
  - [x] black
  - [x] isort
