### PR TITLE
Added filename conventions guide to climate profiles readme

### DIFF
--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -27,6 +27,20 @@ Examples:
 
 
 #### Components
+
+| Component | Description | Options |
+|--------|-------------|--------|
+| `STATION_NAME` | Weather station identifier | e.g., `palm_springs_regional_airport_kpsp` |
+| `VARIABLE` | Climate variable measured | `t2` – Air temperature at 2m<br>`rh_derived` – Relative humidity<br>`wind_speed_derived` – Wind speed<br>`swdnb` – Solar radiation / Shortwave downward normal beam radiation<br>`noaa_heat_index_derived` – NOAA heat index |
+| `PERCENTILE` | Statistical percentile | `05ptile` – 5th percentile<br>`50ptile` – 50th percentile / median<br>`95ptile` – 95th percentile |
+| `GWL_PERIOD` | Global warming level 30-year period | `present-day` – 1.2°C GWL<br>`near-future` – 1.5°C GWL<br>`mid-century` – 2.0°C GWL<br>`mid-late-century` – 2.5°C GWL |
+| `DELTA` | Whether the difference from baseline (delta) was taken | `no_delta`<br>`delta_from_historical` |
+| `WINDOW` | Years around the year in which the input GWL is reached | e.g., `30yr` (corresponding to a 15yr window size) |
+| `APPROACH` | Climate profile approach used | `time`<br>`warming_level` |
+| `CENTERED_YEAR` | For `approach=time`, the year used to find a corresponding warming level | e.g., `2015` |
+| `SCENARIO` | SSP scenario | `ssp245` – SSP 2-4.5<br>`ssp370` – SSP 3-7.0<br>`ssp585` – SSP 5-8.5 |
+| `BA_MODELS` | Return only bias-adjusted models (default: `False`) | `ba_models` |
+
 STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
 
 VARIABLE:       Climate variable measured

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -18,17 +18,18 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 ### Standard Year
 
-stdyr\_[VARIABLE]\_[PERCENTILE]\_[STATION\_NAME]\_[GWL\_PERIOD]\_[DELTA]\_[WINDOW]\_[APPROACH]\_[CENTERED\_YEAR]\_[SCENARIO]\_[BA\_MODELS].[EXTENSION]
-
-stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION\_NAME`\_`GWL\_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED\_YEAR`\_`SCENARIO`\_`BA\_MODELS`.`EXTENSION`
+stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED_YEAR`\_`SCENARIO`\_`BA_MODELS`.`EXTENSION`
 
 Examples:
+
   stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
+
   stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
+
   stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
 
 
-#### Components
+#### Filename Components
 
 | Component | Description | Options |
 |--------|-------------|--------|
@@ -48,7 +49,7 @@ Examples:
 
 ### Typical Meteorological Year
 
-tmy\_[STATION\_NAME]\_[ACTIVITY\_ID]\_[SOURCE\_ID]\_[MEMBER\_ID]\_[GWL\_PERIOD].[EXTENSION]
+tmy\_`STATION_NAME`\_`ACTIVITY_ID`\_`SOURCE`_ID`\_`MEMBER`_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 Examples:
 
@@ -58,7 +59,7 @@ Examples:
 
   tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.tmy
 
-#### Components
+#### Filename Components
 
 | Column | Description | Values |
 |--------|-------------|--------|

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -20,6 +20,8 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 stdyr\_[VARIABLE]\_[PERCENTILE]\_[STATION\_NAME]\_[GWL\_PERIOD]\_[DELTA]\_[WINDOW]\_[APPROACH]\_[CENTERED\_YEAR]\_[SCENARIO]\_[BA\_MODELS].[EXTENSION]
 
+stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION\_NAME`\_`GWL\_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED\_YEAR`\_`SCENARIO`\_`BA\_MODELS`.`EXTENSION`
+
 Examples:
   stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
   stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
@@ -37,50 +39,12 @@ Examples:
 | `DELTA` | Whether the difference from baseline (delta) was taken | `no_delta`<br>`delta_from_historical` |
 | `WINDOW` | Years around the year in which the input GWL is reached | e.g., `30yr` (corresponding to a 15yr window size) |
 | `APPROACH` | Climate profile approach used | `time`<br>`warming_level` |
-| `CENTERED_YEAR` | For `approach=time`, the year used to find a corresponding warming level | e.g., `2015` |
+| `CENTERED_YEAR` | For approach='Time', the year used to find a corresponding warming level | e.g., `2015` |
 | `SCENARIO` | SSP scenario | `ssp245` – SSP 2-4.5<br>`ssp370` – SSP 3-7.0<br>`ssp585` – SSP 5-8.5 |
-| `BA_MODELS` | Return only bias-adjusted models (default: `False`) | `ba_models` |
+| `BA_MODELS` | Return only bias-adjusted models (default: False) | `ba_models` |
 
-STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
 
-VARIABLE:       Climate variable measured
-                - t2 (Air temperature at 2m)
-                - rh_derived (Relative humidity)
-                - wind_speed_derived (Wind speed)
-                - swdnb (Solar radiation / Shortwave downward normal beam radiation)
-                - noaa_heat_index_derived (NOAA heat index)
 
-PERCENTILE:     Statistical percentile
-                - 05ptile (5th percentile)
-                - 50ptile (50th percentile/median)
-                - 95ptile (95th percentile)
-
-GWL_PERIOD:     Global warming level 30-year period
-                - present-day (1.2 degC GWL)
-                - near-future (1.5 degC GWL)
-                - mid-century (2.0 degC GWL)
-                - mid-late-century (2.5 degC GWL)
-
-DELTA:          Weather or not the difference from baseline (delta) was taken
-                - no_delta
-                - delta_from_historical
-
-WINDOW:          Years around the year in which the input Global Warming Level is reached. 
-                - ex: 30yr (corresponding to a 15yr window size)
-APPROACH:        The climate profile approach that was used.
-                - time
-                - warming_level
-
-CENTERED_YEAR:  For approach="Time", the year for which to find a corresponding warming level
-                - ex: 2015
-
-SCENARIO       SSP scenario from ["SSP 3-7.0", "SSP 2-4.5","SSP 5-8.5"]
-                - ssp245
-                - ssp370
-                - ssp585
-
-BA_MODELS     Option to return only bias-adjusted models. Default = False
-                - ba_models 
 
 ### Typical Meteorological Year
 
@@ -96,19 +60,11 @@ Examples:
 
 #### Components
 
-STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
-
-SOURCE_ID:      Climate model source (e.g., mpi-esm1-2-hr, miroc6, ec-earth3, taiesm1)
-
-GWL_PERIOD:     Global warming level 30-year period
-
-                - present-day (1.2 degC GWL)
-
-                - near-future (1.5 degC GWL)
-
-                - mid-century (2.0 degC GWL)
-
-                - mid-late-century (2.5 degC GWL)
+| Column | Description | Values |
+|--------|-------------|--------|
+| `STATION_NAME` | Weather station identifier | e.g., `palm_springs_regional_airport_kpsp` |
+| `SOURCE_ID` | Climate model source | e.g., `mpi-esm1-2-hr`, `miroc6`, `ec-earth3`, `taiesm1` |
+| `GWL_PERIOD` | Global warming level 30-year period | `present-day` – 1.2°C GWL<br>`near-future` – 1.5°C GWL<br>`mid-century` – 2.0°C GWL<br>`mid-late-century` – 2.5°C GWL |
 
 Additional metadata in filenames and intake catalog:
 

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -64,9 +64,3 @@ tmy\_`STATION_NAME`\_WRF_`SOURCE`_ID`\_`GWL_PERIOD`.`EXTENSION`
 | `SOURCE_ID` | Climate model source | e.g., `mpi-esm1-2-hr`, `miroc6`, `ec-earth3`, `taiesm1` |
 | `GWL_PERIOD` | Global warming level 30-year period | `present-day` – 1.2°C GWL<br>`near-future` – 1.5°C GWL<br>`mid-century` – 2.0°C GWL<br>`mid-late-century` – 2.5°C GWL |
 
-**Additional metadata in filenames and intake catalog:**
-
-ACTIVITY_ID:    Downscaling method 
-
-MEMBER_ID:      Ensemble member identifier (e.g., r1i1p1f1, r3i1p1f1)
-

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -47,7 +47,7 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 
 ### Typical Meteorological Year
 
-tmy\_`STATION_NAME`\_WRF_`SOURCE_ID`\_`GWL_PERIOD`.`EXTENSION`
+tmy\_`STATION_NAME`\_wrf_`SOURCE_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 **Examples:**
   - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -21,10 +21,12 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED_YEAR`\_`SCENARIO`\_`BA_MODELS`.`EXTENSION`
 
 **Examples:**
+  - stdyr_t2_50ptile_sacramento_executive_airport_ksac_present-day_delta_from_historical_30yr_window_warming_level.csv
+  - stdyr_t2_50ptile_sacramento_executive_airport_ksac_mid-late-century_delta_from_historical_30yr_window.epw
   - stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
   - stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
   - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
-  - stdyr_t2_50ptile_sacramento_executive_airport_ksac_present-day_delta_from_historical_30yr_window_warming_level
+
 
 
 #### Filename Components

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -49,7 +49,7 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 
 ### Typical Meteorological Year
 
-tmy\_`STATION_NAME`\_`ACTIVITY_ID`\_`SOURCE`_ID`\_`MEMBER`_ID`\_`GWL_PERIOD`.`EXTENSION`
+tmy\_`STATION_NAME`\_WRF_`SOURCE`_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 **Examples:**
   - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -25,7 +25,7 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
   - stdyr_t2_50ptile_sacramento_executive_airport_ksac_mid-late-century_delta_from_historical_30yr_window.epw
   - stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
   - stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
-  - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
+  - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.csv
 
 
 

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -20,13 +20,11 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED_YEAR`\_`SCENARIO`\_`BA_MODELS`.`EXTENSION`
 
-Examples:
+**Examples:**
 
-  stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
-
-  stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
-
-  stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
+  - stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
+  - stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
+  - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
 
 
 #### Filename Components
@@ -51,13 +49,11 @@ Examples:
 
 tmy\_`STATION_NAME`\_`ACTIVITY_ID`\_`SOURCE`_ID`\_`MEMBER`_ID`\_`GWL_PERIOD`.`EXTENSION`
 
-Examples:
+**Examples:**
 
-  tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv
-
-  tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.epw
-
-  tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.tmy
+  - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv
+  - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.epw
+  - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.tmy
 
 #### Filename Components
 

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -22,7 +22,7 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 
 **Examples:**
   - stdyr_t2_50ptile_sacramento_executive_airport_ksac_present-day_delta_from_historical_30yr_window_warming_level.csv
-  - stdyr_t2_50ptile_sacramento_executive_airport_ksac_mid-late-century_delta_from_historical_30yr_window.epw
+  - stdyr_t2_50ptile_sacramento_executive_airport_ksac_mid-late-century_delta_from_historical_30yr_window.csv
   - stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
   - stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
   - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.csv

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -47,7 +47,7 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 
 ### Typical Meteorological Year
 
-tmy\_`STATION_NAME`\_WRF_`SOURCE`_ID`\_`GWL_PERIOD`.`EXTENSION`
+tmy\_`STATION_NAME`\_WRF_`SOURCE_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 **Examples:**
   - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -18,7 +18,7 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 ### Standard Year
 
-stdyr_[VARIABLE]_[PERCENTILE]_[STATION_NAME]_[GWL_PERIOD]_[DELTA]_[WINDOW]_[APPROACH]_[CENTERED_YEAR]_[SCENARIO]_[BA_MODELS].csv
+stdyr_<br>VARIABLE<br>_<br>PERCENTILE<br>_<br>STATION_NAME<br>_<br>GWL_PERIOD<br>_[DELTA]_[WINDOW]_[APPROACH]_[CENTERED_YEAR]_[SCENARIO]_[BA_MODELS].csv
 
 Examples:
   stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
@@ -26,38 +26,45 @@ Examples:
   stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
 
 
-Components
-----------
+#### Components
 STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
+
 VARIABLE:       Climate variable measured
                 - t2 (Air temperature at 2m)
                 - rh_derived (Relative humidity)
                 - wind_speed_derived (Wind speed)
                 - swdnb (Solar radiation / Shortwave downward normal beam radiation)
                 - noaa_heat_index_derived (NOAA heat index)
+
 PERCENTILE:     Statistical percentile
                 - 05ptile (5th percentile)
                 - 50ptile (50th percentile/median)
                 - 95ptile (95th percentile)
+
 GWL_PERIOD:     Global warming level 30-year period
                 - present-day (1.2 degC GWL)
                 - near-future (1.5 degC GWL)
                 - mid-century (2.0 degC GWL)
                 - mid-late-century (2.5 degC GWL)
+
 DELTA:          Weather or not the difference from baseline (delta) was taken
                 - no_delta
                 - delta_from_historical
+
 WINDOW:          Years around the year in which the input Global Warming Level is reached. 
                 - ex: 30yr (corresponding to a 15yr window size)
 APPROACH:        The climate profile approach that was used.
                 - time
                 - warming_level
+
 CENTERED_YEAR:  For approach="Time", the year for which to find a corresponding warming level
                 - ex: 2015
+
 SCENARIO       SSP scenario from ["SSP 3-7.0", "SSP 2-4.5","SSP 5-8.5"]
                 - ssp245
                 - ssp370
                 - ssp585
+
 BA_MODELS     Option to return only bias-adjusted models. Default = False
                 - ba_models 
 
@@ -66,20 +73,32 @@ BA_MODELS     Option to return only bias-adjusted models. Default = False
 tmy_[STATION_NAME]_[ACTIVITY_ID]_[SOURCE_ID]_[MEMBER_ID]_[GWL_PERIOD].[EXTENSION]
 
 Examples:
+
   tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv
+
   tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.epw
+
   tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.tmy
 
-Components
-----------
+#### Components
+
 STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
+
 SOURCE_ID:      Climate model source (e.g., mpi-esm1-2-hr, miroc6, ec-earth3, taiesm1)
+
 GWL_PERIOD:     Global warming level 30-year period
+
                 - present-day (1.2 degC GWL)
+
                 - near-future (1.5 degC GWL)
+
                 - mid-century (2.0 degC GWL)
+
                 - mid-late-century (2.5 degC GWL)
 
 Additional metadata in filenames and intake catalog:
+
 ACTIVITY_ID:    Downscaling method 
+
 MEMBER_ID:      Ensemble member identifier (e.g., r1i1p1f1, r3i1p1f1)
+

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -18,11 +18,68 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 ### Standard Year
 
-stdyr_[VARIABLE]_[PERCENTILE]_[STATION_NAME]_[GWL_PERIOD].csv
+stdyr_[VARIABLE]_[PERCENTILE]_[STATION_NAME]_[GWL_PERIOD]_[DELTA]_[WINDOW]_[APPROACH]_[CENTERED_YEAR]_[SCENARIO]_[BA_MODELS].csv
 
-Example:
-  stdyr_noaa_heat_index_derived_95ptile_palm_springs_regional_airport_kpsp_mid-century_.csv
+Examples:
+  stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
+  stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
+  stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
 
+
+Components
+----------
+STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
+VARIABLE:       Climate variable measured
+                - t2 (Air temperature at 2m)
+                - rh_derived (Relative humidity)
+                - wind_speed_derived (Wind speed)
+                - swdnb (Solar radiation / Shortwave downward normal beam radiation)
+                - noaa_heat_index_derived (NOAA heat index)
+PERCENTILE:     Statistical percentile
+                - 05ptile (5th percentile)
+                - 50ptile (50th percentile/median)
+                - 95ptile (95th percentile)
+GWL_PERIOD:     Global warming level 30-year period
+                - present-day (1.2 degC GWL)
+                - near-future (1.5 degC GWL)
+                - mid-century (2.0 degC GWL)
+                - mid-late-century (2.5 degC GWL)
+DELTA:          Weather or not the difference from baseline (delta) was taken
+                - no_delta
+                - delta_from_historical
+WINDOW:          Years around the year in which the input Global Warming Level is reached. 
+                - ex: 30yr (corresponding to a 15yr window size)
+APPROACH:        The climate profile approach that was used.
+                - time
+                - warming_level
+CENTERED_YEAR:  For approach="Time", the year for which to find a corresponding warming level
+                - ex: 2015
+SCENARIO       SSP scenario from ["SSP 3-7.0", "SSP 2-4.5","SSP 5-8.5"]
+                - ssp245
+                - ssp370
+                - ssp585
+BA_MODELS     Option to return only bias-adjusted models. Default = False
+                - ba_models 
 
 ### Typical Meteorological Year
 
+tmy_[STATION_NAME]_[ACTIVITY_ID]_[SOURCE_ID]_[MEMBER_ID]_[GWL_PERIOD].[EXTENSION]
+
+Examples:
+  tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv
+  tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.epw
+  tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.tmy
+
+Components
+----------
+STATION_NAME:   Weather station identifier (e.g., palm_springs_regional_airport_kpsp)
+SOURCE_ID:      Climate model source (e.g., mpi-esm1-2-hr, miroc6, ec-earth3, taiesm1)
+GWL_PERIOD:     Global warming level 30-year period
+                - present-day (1.2 degC GWL)
+                - near-future (1.5 degC GWL)
+                - mid-century (2.0 degC GWL)
+                - mid-late-century (2.5 degC GWL)
+
+Additional metadata in filenames and intake catalog:
+ACTIVITY_ID:    Downscaling method 
+MEMBER_ID:      Ensemble member identifier (e.g., r1i1p1f1, r3i1p1f1)

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -18,7 +18,7 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 ### Standard Year
 
-stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED_YEAR`\_`SCENARIO`\_`BA_MODELS`.`EXTENSION`
+stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED_YEAR`\_`SCENARIO`\_`BA_MODELS`.csv
 
 **Examples:**
   - stdyr_t2_50ptile_sacramento_executive_airport_ksac_present-day_delta_from_historical_30yr_window_warming_level.csv
@@ -33,9 +33,9 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 
 | Component | Description | Options |
 |--------|-------------|--------|
-| `STATION_NAME` | Weather station identifier | e.g., `palm_springs_regional_airport_kpsp` |
 | `VARIABLE` | Climate variable measured | `t2` – Air temperature at 2m<br>`rh_derived` – Relative humidity<br>`wind_speed_derived` – Wind speed<br>`swdnb` – Solar radiation / Shortwave downward normal beam radiation<br>`noaa_heat_index_derived` – NOAA heat index |
 | `PERCENTILE` | Statistical percentile | `05ptile` – 5th percentile<br>`50ptile` – 50th percentile / median<br>`95ptile` – 95th percentile |
+| `STATION_NAME` | Weather station identifier | e.g., `palm_springs_regional_airport_kpsp` |
 | `GWL_PERIOD` | Global warming level 30-year period | `present-day` – 1.2°C GWL<br>`near-future` – 1.5°C GWL<br>`mid-century` – 2.0°C GWL<br>`mid-late-century` – 2.5°C GWL |
 | `DELTA` | Whether the difference from baseline (delta) was taken | `no_delta` - no delta taken <br>`delta_from_historical` - delta taken |
 | `WINDOW` | Years around the year in which the input GWL is reached | e.g., `30yr` (corresponding to a 15yr window size) |
@@ -43,8 +43,6 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 | `CENTERED_YEAR` | For approach='Time', the year used to find a corresponding warming level | e.g., `2015` |
 | `SCENARIO` | SSP scenario (default: `ssp370`) | `ssp245` – SSP 2-4.5<br>`ssp370` – SSP 3-7.0<br>`ssp585` – SSP 5-8.5 |
 | `BA_MODELS` | If only bias-adjusted models were used (default: FALSE) | `ba_models` - TRUE |
-
-
 
 
 ### Typical Meteorological Year

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -18,7 +18,7 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 
 ### Standard Year
 
-stdyr_<br>VARIABLE<br>_<br>PERCENTILE<br>_<br>STATION_NAME<br>_<br>GWL_PERIOD<br>_[DELTA]_[WINDOW]_[APPROACH]_[CENTERED_YEAR]_[SCENARIO]_[BA_MODELS].csv
+stdyr\_[VARIABLE]\_[PERCENTILE]\_[STATION\_NAME]\_[GWL\_PERIOD]\_[DELTA]\_[WINDOW]\_[APPROACH]\_[CENTERED\_YEAR]\_[SCENARIO]\_[BA\_MODELS].[EXTENSION]
 
 Examples:
   stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
@@ -70,7 +70,7 @@ BA_MODELS     Option to return only bias-adjusted models. Default = False
 
 ### Typical Meteorological Year
 
-tmy_[STATION_NAME]_[ACTIVITY_ID]_[SOURCE_ID]_[MEMBER_ID]_[GWL_PERIOD].[EXTENSION]
+tmy\_[STATION\_NAME]\_[ACTIVITY\_ID]\_[SOURCE\_ID]\_[MEMBER\_ID]\_[GWL\_PERIOD].[EXTENSION]
 
 Examples:
 

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -3,6 +3,8 @@ Climate Profiles Notebooks
 
 This folder will house notebooks that can be used to generate custom Climate Profiles hourly datasets (8760s), including Standard Year Profile (single variable), Typical Meteorological Years (TMY, multivariable), and 8760s.
 
+## Notebooks
+
 [custom_climate_profiles.ipynb](custom_climate_profiles.ipynb): Generate a custom hourly climate profile a single location.  *In development*
 
 *For example: How do I generate a TMY in .epw format for the Los Angeles International Airport location using climate model data?*
@@ -11,4 +13,16 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 [typical_meteorological_year_methodology.ipynb](typical_meteorological_year_methodology.ipynb): Explore the full methodology of a Typical Meteorological Year to represent the typical climatological conditions over one year of hourly data.  
 
 *For example: What will an average year of hourly temperature data look like in a 2°C warmer world?*
+
+## Filename Conventions
+
+### Standard Year
+
+stdyr_[VARIABLE]_[PERCENTILE]_[STATION_NAME]_[GWL_PERIOD].csv
+
+Example:
+  stdyr_noaa_heat_index_derived_95ptile_palm_springs_regional_airport_kpsp_mid-century_.csv
+
+
+### Typical Meteorological Year
 

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -56,7 +56,7 @@ tmy\_`STATION_NAME`\_wrf_`SOURCE_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 #### Filename Components
 
-| Column | Description | Options |
+| Component | Description | Options |
 |--------|-------------|--------|
 | `STATION_NAME` | Weather station identifier | e.g., `palm_springs_regional_airport_kpsp` |
 | `SOURCE_ID` | Climate model source | e.g., `mpi-esm1-2-hr`, `miroc6`, `ec-earth3`, `taiesm1` |

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -34,12 +34,12 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 | `VARIABLE` | Climate variable measured | `t2` – Air temperature at 2m<br>`rh_derived` – Relative humidity<br>`wind_speed_derived` – Wind speed<br>`swdnb` – Solar radiation / Shortwave downward normal beam radiation<br>`noaa_heat_index_derived` – NOAA heat index |
 | `PERCENTILE` | Statistical percentile | `05ptile` – 5th percentile<br>`50ptile` – 50th percentile / median<br>`95ptile` – 95th percentile |
 | `GWL_PERIOD` | Global warming level 30-year period | `present-day` – 1.2°C GWL<br>`near-future` – 1.5°C GWL<br>`mid-century` – 2.0°C GWL<br>`mid-late-century` – 2.5°C GWL |
-| `DELTA` | Whether the difference from baseline (delta) was taken | `no_delta`<br>`delta_from_historical` |
+| `DELTA` | Whether the difference from baseline (delta) was taken | `no_delta` - no delta taken <br>`delta_from_historical` - delta taken |
 | `WINDOW` | Years around the year in which the input GWL is reached | e.g., `30yr` (corresponding to a 15yr window size) |
 | `APPROACH` | Climate profile approach used | `time`<br>`warming_level` |
 | `CENTERED_YEAR` | For approach='Time', the year used to find a corresponding warming level | e.g., `2015` |
-| `SCENARIO` | SSP scenario | `ssp245` – SSP 2-4.5<br>`ssp370` – SSP 3-7.0<br>`ssp585` – SSP 5-8.5 |
-| `BA_MODELS` | Return only bias-adjusted models (default: False) | `ba_models` |
+| `SCENARIO` | SSP scenario (default: `ssp370`) | `ssp245` – SSP 2-4.5<br>`ssp370` – SSP 3-7.0<br>`ssp585` – SSP 5-8.5 |
+| `BA_MODELS` | If only bias-adjusted models were used (default: FALSE) | `ba_models` - TRUE |
 
 
 
@@ -61,7 +61,7 @@ tmy\_`STATION_NAME`\_`ACTIVITY_ID`\_`SOURCE`_ID`\_`MEMBER`_ID`\_`GWL_PERIOD`.`EX
 | `SOURCE_ID` | Climate model source | e.g., `mpi-esm1-2-hr`, `miroc6`, `ec-earth3`, `taiesm1` |
 | `GWL_PERIOD` | Global warming level 30-year period | `present-day` – 1.2°C GWL<br>`near-future` – 1.5°C GWL<br>`mid-century` – 2.0°C GWL<br>`mid-late-century` – 2.5°C GWL |
 
-Additional metadata in filenames and intake catalog:
+**Additional metadata in filenames and intake catalog:**
 
 ACTIVITY_ID:    Downscaling method 
 

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -21,7 +21,6 @@ This folder will house notebooks that can be used to generate custom Climate Pro
 stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`\_`APPROACH`\_`CENTERED_YEAR`\_`SCENARIO`\_`BA_MODELS`.`EXTENSION`
 
 **Examples:**
-
   - stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
   - stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
   - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
@@ -50,7 +49,6 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
 tmy\_`STATION_NAME`\_`ACTIVITY_ID`\_`SOURCE`_ID`\_`MEMBER`_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 **Examples:**
-
   - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.csv
   - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.epw
   - tmy_palm_springs_regional_airport_kpsp_wrf_mpi-esm1-2-hr_r3i1p1f1_mid-century.tmy

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -24,6 +24,7 @@ stdyr\_`VARIABLE`\_`PERCENTILE`\_`STATION_NAME`\_`GWL_PERIOD`\_`DELTA`\_`WINDOW`
   - stdyr_t2_50ptile_san_diego_lindbergh_field_ksan_30yr_window_time_2020_ssp370.csv
   - stdyr_prec_75ptile_35-5N_122-5W_delta_from_historical_10yr_window_time_2016_ssp370_ba_models.csv
   - stdyr_rh_derived_50ptile_santa_barbara_municipal_airport_ksba_delta_from_historical_30yr_window_time_2015_ssp370.epw
+  - stdyr_t2_50ptile_sacramento_executive_airport_ksac_present-day_delta_from_historical_30yr_window_warming_level
 
 
 #### Filename Components

--- a/climate-profiles/README.md
+++ b/climate-profiles/README.md
@@ -56,7 +56,7 @@ tmy\_`STATION_NAME`\_wrf_`SOURCE_ID`\_`GWL_PERIOD`.`EXTENSION`
 
 #### Filename Components
 
-| Column | Description | Values |
+| Column | Description | Options |
 |--------|-------------|--------|
 | `STATION_NAME` | Weather station identifier | e.g., `palm_springs_regional_airport_kpsp` |
 | `SOURCE_ID` | Climate model source | e.g., `mpi-esm1-2-hr`, `miroc6`, `ec-earth3`, `taiesm1` |

--- a/climate-profiles/custom_climate_profiles.ipynb
+++ b/climate-profiles/custom_climate_profiles.ipynb
@@ -206,7 +206,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (climakitae)",
+   "display_name": "climakitae",
    "language": "python",
    "name": "python3"
   },
@@ -220,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary of changes
I added a breakdown of  TMY and SY filenames in the readme for the custom profiles folder. 

## Link to corresponding Jira ticket(s)
https://eaglerockanalytics.atlassian.net/jira/software/c/projects/ERA/boards/20?selectedIssue=AE-1027

## Naming & Organization
- [ ] Notebook name follows conventions:
  - [ ] Avoids acronyms and jargon where possible
  - [ ] References primary use of the notebook
  - [ ] Uses Action + Objective format (e.g., "calculate_heat_index", "calculate_annual_trends")
  - [ ] Prioritizes clarity over brevity (within reason)
- [ ] Notebook placed in appropriate directory for maximum usability
- [ ] All referenced guides/documentation updated:
  - [x] README updated
  - [ ] Navigation Guide updated

## Content & Documentation
- [ ] Introduction clearly explains the purpose of the analysis
- [ ] Intended application of the notebook listed
  - User-focused question/example provided showing how a user may want to use the notebook
- [ ] Incorporates references to appropriate Guidance materials
- [ ] Error messages included for areas with common user errors

## Runtime Information
- [ ] Overall runtime on AE JupyterHub documented

## Output Management
- [ ] Output from cells removed before committing

## Code Quality
- [ ] Notebook cleaned up with:
  - [ ] black
  - [ ] isort
